### PR TITLE
fix : single phone field on eventType and booking page

### DIFF
--- a/apps/web/modules/bookings/views/bookings-single-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-single-view.tsx
@@ -26,11 +26,7 @@ import {
   useIsEmbed,
 } from "@calcom/embed-core/embed-iframe";
 import { Price } from "@calcom/features/bookings/components/event-meta/Price";
-import {
-  SMS_REMINDER_NUMBER_FIELD,
-  SystemField,
-  TITLE_FIELD,
-} from "@calcom/features/bookings/lib/SystemField";
+import { SystemField, TITLE_FIELD } from "@calcom/features/bookings/lib/SystemField";
 import { getCalendarLinks, CalendarLinkType } from "@calcom/lib/bookings/getCalendarLinks";
 import { APP_NAME } from "@calcom/lib/constants";
 import { formatToLocalizedDate, formatToLocalizedTime, formatToLocalizedTimezone } from "@calcom/lib/dayjs";
@@ -767,7 +763,7 @@ export default function Success(props: PageProps) {
                           // TITLE is also an identifier for booking question "What is this meeting about?"
                           if (
                             isSystemField.success &&
-                            field.name !== SMS_REMINDER_NUMBER_FIELD &&
+                            //field.name !== SMS_REMINDER_NUMBER_FIELD &&
                             field.name !== TITLE_FIELD
                           )
                             return null;

--- a/packages/features/bookings/Booker/components/BookEventForm/BookingFields.tsx
+++ b/packages/features/bookings/Booker/components/BookEventForm/BookingFields.tsx
@@ -64,11 +64,13 @@ export const BookingFields = ({
           readOnly = false;
         }
 
-        if (field.name === SystemField.Enum.smsReminderNumber) {
+        // if (field.name === SystemField.Enum.smsReminderNumber) {
+        if (field.name === SystemField.Enum.attendeePhoneNumber) {
           // `smsReminderNumber` and location.optionValue when location.value===phone are the same data point. We should solve it in a better way in the Form Builder itself.
           // I think we should have a way to connect 2 fields together and have them share the same value in Form Builder
           if (locationResponse?.value === "phone") {
-            setValue(`responses.${SystemField.Enum.smsReminderNumber}`, locationResponse?.optionValue);
+            // setValue(`responses.${SystemField.Enum.smsReminderNumber}`, locationResponse?.optionValue);
+            setValue(`responses.${SystemField.Enum.attendeePhoneNumber}`, locationResponse?.optionValue);
             // Just don't render the field now, as the value is already connected to attendee phone location
             return null;
           }

--- a/packages/features/bookings/lib/SystemField.ts
+++ b/packages/features/bookings/lib/SystemField.ts
@@ -8,9 +8,9 @@ export const SystemField = z.enum([
   "notes",
   "guests",
   "rescheduleReason",
-  "smsReminderNumber",
+  //"smsReminderNumber",
   "attendeePhoneNumber",
 ]);
 
-export const SMS_REMINDER_NUMBER_FIELD = "smsReminderNumber";
+export const SMS_REMINDER_NUMBER_FIELD = "attendeePhoneNumber";
 export const TITLE_FIELD = "title";

--- a/packages/features/bookings/lib/getCalEventResponses.ts
+++ b/packages/features/bookings/lib/getCalEventResponses.ts
@@ -48,10 +48,17 @@ export const getCalEventResponses = ({
       backwardCompatibleResponses["attendeePhoneNumber"]
     );
   }
+  //for showing correct Parsed Phone field on Calendar Page
+  const phonefield: Record<string, string> = {
+    number_text_notifications: "Phone Number (text notification)",
+    phone: "Phone Number",
+    phone_number: "Phone Number",
+  };
 
   if (parsedBookingFields) {
     parsedBookingFields.forEach((field) => {
-      const label = field.label || field.defaultLabel;
+      const dynamicLabel = field.defaultLabel ? phonefield[field.defaultLabel] : undefined;
+      const label = dynamicLabel || field.label || field.defaultLabel;
       if (!label) {
         //TODO: This error must be thrown while saving event-type as well so that such an event-type can't be saved
         throw new Error(`Missing label for booking field "${field.name}"`);

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -1282,7 +1282,7 @@ async function handler(
       attendeeLanguage,
       paymentAppData,
       fullName,
-      smsReminderNumber,
+      smsReminderNumber: bookerPhoneNumber,
       eventTypeInfo,
       uid,
       eventTypeId,
@@ -1395,7 +1395,7 @@ async function handler(
         input: {
           bookerEmail,
           rescheduleReason,
-          smsReminderNumber,
+          smsReminderNumber: bookerPhoneNumber,
           responses,
         },
         evt,
@@ -1973,7 +1973,8 @@ async function handler(
     metadata: { ...metadata, ...reqBody.metadata },
     eventTypeId,
     status: "ACCEPTED",
-    smsReminderNumber: booking?.smsReminderNumber || undefined,
+    // smsReminderNumber: booking?.smsReminderNumber || undefined,
+    smsReminderNumber: bookerPhoneNumber || undefined,
     rescheduledBy: reqBody.rescheduledBy,
     ...(assignmentReason ? { assignmentReason: [assignmentReason] } : {}),
   };
@@ -2204,7 +2205,8 @@ async function handler(
   try {
     await scheduleWorkflowReminders({
       workflows,
-      smsReminderNumber: smsReminderNumber || null,
+      // smsReminderNumber: smsReminderNumber || null,
+      smsReminderNumber: bookerPhoneNumber || null,
       calendarEvent: evtWithMetadata,
       isNotConfirmed: rescheduleUid ? false : !isConfirmedByDefault,
       isRescheduleEvent: !!rescheduleUid,

--- a/packages/features/bookings/lib/handleNewBooking/getEventType.ts
+++ b/packages/features/bookings/lib/handleNewBooking/getEventType.ts
@@ -19,7 +19,11 @@ const _getEventType = async ({
 
   return {
     ...eventType,
-    bookingFields: getBookingFieldsWithSystemFields({ ...eventType, isOrgTeamEvent }),
+    bookingFields: getBookingFieldsWithSystemFields({
+      ...eventType,
+      isOrgTeamEvent,
+      workflows: eventType.calIdWorkflows,
+    }),
   };
 };
 

--- a/packages/features/eventtypes/lib/bookingFieldsManager.ts
+++ b/packages/features/eventtypes/lib/bookingFieldsManager.ts
@@ -59,7 +59,7 @@ async function getEventType(eventTypeId: EventType["id"]) {
  * @param eventTypeId
  */
 export async function upsertBookingField(
-  fieldToAdd: Omit<Field, "required">,
+  //fieldToAdd: Omit<Field, "required">,
   source: NonNullable<Field["sources"]>[number],
   eventTypeId: EventType["id"]
 ) {
@@ -67,7 +67,8 @@ export async function upsertBookingField(
   let fieldFound = false;
 
   const newFields = eventType.bookingFields.map((f) => {
-    if (f.name === fieldToAdd.name) {
+    // if (f.name === fieldToAdd.name) {
+    if (f.name === "attendeePhoneNumber") {
       fieldFound = true;
 
       const currentSources = f.sources ? f.sources : ([] as NonNullable<typeof f.sources>[]);
@@ -93,18 +94,19 @@ export async function upsertBookingField(
         // If any source requires the field, mark the field required
         required: newSources.some((s) => s.fieldRequired),
         sources: newSources,
+        hidden: false,
       };
       return newField;
     }
     return f;
   });
-  if (!fieldFound) {
-    newFields.push({
-      ...fieldToAdd,
-      required: source.fieldRequired,
-      sources: [source],
-    });
-  }
+  // if (!fieldFound) {
+  //   newFields.push({
+  //     ...fieldToAdd,
+  //     required: source.fieldRequired,
+  //     sources: [source],
+  //   });
+  // }
   await prisma.eventType.update({
     where: {
       id: eventTypeId,

--- a/packages/features/eventtypes/lib/getPublicEvent.ts
+++ b/packages/features/eventtypes/lib/getPublicEvent.ts
@@ -529,7 +529,16 @@ export const getPublicEvent = async (
     metadata: eventMetaData,
     customInputs: customInputSchema.array().parse(event.customInputs || []),
     locations: privacyFilteredLocations((eventWithUserProfiles.locations || []) as LocationObject[]),
-    bookingFields: getBookingFieldsWithSystemFields(event),
+    // bookingFields: getBookingFieldsWithSystemFields(event),
+    //for passing workflow to booking Page
+    bookingFields: getBookingFieldsWithSystemFields({
+      bookingFields: event.bookingFields,
+      disableGuests: event.disableGuests,
+      customInputs: event.customInputs || [],
+      metadata: event.metadata,
+      workflows: event.calIdWorkflows || [],
+      isOrgTeamEvent: !!event.teamId,
+    }),
     recurringEvent: isRecurringEvent(eventWithUserProfiles.recurringEvent)
       ? parseRecurringEvent(event.recurringEvent)
       : null,
@@ -1028,7 +1037,16 @@ export const processEventDataShared = async ({
     metadata,
     customInputs: customInputSchema.array().parse(eventData.customInputs || []),
     locations: privacyFilteredLocations((eventData.locations || []) as LocationObject[]),
-    bookingFields: getBookingFieldsWithSystemFields(eventData),
+    // bookingFields: getBookingFieldsWithSystemFields(eventData),
+    //for passing workflow to booking Page
+    bookingFields: getBookingFieldsWithSystemFields({
+      bookingFields: eventData.bookingFields,
+      disableGuests: eventData.disableGuests,
+      customInputs: eventData.customInputs || [],
+      metadata: eventData.metadata,
+      workflows: eventData.calIdWorkflows || [], // ← ADD THIS
+      isOrgTeamEvent: !!eventData.teamId,
+    }),
     recurringEvent: isRecurringEvent(eventData.recurringEvent)
       ? parseRecurringEvent(eventData.recurringEvent)
       : null,

--- a/packages/features/form-builder/FormBuilder.tsx
+++ b/packages/features/form-builder/FormBuilder.tsx
@@ -1,7 +1,4 @@
 import { Icon } from "@calid/features/ui/components/icon";
-
-
-
 import { useAutoAnimate } from "@formkit/auto-animate/react";
 import { useEffect, useState } from "react";
 import type { SubmitHandler, UseFormReturn } from "react-hook-form";
@@ -142,6 +139,9 @@ export const FormBuilder = function FormBuilder({
               value={(() => {
                 const phoneField = fields.find((field) => field.name === "attendeePhoneNumber");
                 const emailField = fields.find((field) => field.name === "email");
+                //check if sms/whatsapp workflow is enabled then disable the toggle
+                const hasWorkflow = phoneField?.sources?.some((s) => s.label === "CalIdWorkflow");
+                if (hasWorkflow) return "phone";
 
                 if (phoneField && !phoneField.hidden && phoneField.required && !emailField?.required) {
                   return "phone";
@@ -161,9 +161,21 @@ export const FormBuilder = function FormBuilder({
                   iconLeft: <Icon name="phone" className="h-4 w-4" />,
                 },
               ]}
+              disabled={(() => {
+                const phoneField = fields.find((field) => field.name === "attendeePhoneNumber");
+                const hasWorkflowSource = phoneField?.sources?.some((s) => s.label === "CalIdWorkflow");
+                return hasWorkflowSource || false;
+              })()}
               onValueChange={(value) => {
                 const phoneFieldIndex = fields.findIndex((field) => field.name === "attendeePhoneNumber");
                 const emailFieldIndex = fields.findIndex((field) => field.name === "email");
+
+                const phoneField = fields[phoneFieldIndex];
+                const hasWorkflowSource = phoneField?.sources?.some((s) => s.label === "CalIdWorkflow");
+
+                if (hasWorkflowSource) {
+                  return;
+                }
                 if (value === "email") {
                   update(emailFieldIndex, {
                     ...fields[emailFieldIndex],
@@ -306,7 +318,8 @@ export const FormBuilder = function FormBuilder({
                     {!isFieldEditableSystem && !isFieldEditableSystemButHidden && !disabled && (
                       <Switch
                         data-testid="toggle-field"
-                        disabled={isFieldEditableSystem}
+                        // disabled={isFieldEditableSystem}
+                        disabled={field.sources?.some((s) => s.label === "CalIdWorkflow")}
                         checked={!field.hidden}
                         onCheckedChange={(checked) => {
                           update(index, { ...field, hidden: !checked });

--- a/packages/features/form-builder/FormBuilderField.tsx
+++ b/packages/features/form-builder/FormBuilderField.tsx
@@ -142,7 +142,6 @@ const WithLabel = ({
   htmlFor: string;
 }) => {
   const { t } = useLocale();
-
   return (
     <div>
       {/* multiemail doesnt show label initially. It is shown on clicking CTA */}
@@ -164,7 +163,10 @@ const WithLabel = ({
             </div>
           )}
       {children}
-      {field.name === "smsReminderNumber" && (
+      {/* {field.name === "smsReminderNumber" && (
+        <div className="text-sm text-gray-500">{t("sms_workflow_consent")}</div>
+      )} */}
+      {field.name === "attendeePhoneNumber" && field.sources?.some((s) => s.label === "CalIdWorkflow") && (
         <div className="text-sm text-gray-500">{t("sms_workflow_consent")}</div>
       )}
     </div>

--- a/packages/lib/event-types/getEventTypeById.ts
+++ b/packages/lib/event-types/getEventTypeById.ts
@@ -228,7 +228,11 @@ export const getEventTypeById = async ({
     users: eventTypeUsers,
     periodStartDate: eventType.periodStartDate?.toString() ?? null,
     periodEndDate: eventType.periodEndDate?.toString() ?? null,
-    bookingFields: getBookingFieldsWithSystemFields({ ...eventType, isOrgTeamEvent }),
+    bookingFields: getBookingFieldsWithSystemFields({
+      ...eventType,
+      isOrgTeamEvent,
+      workflows: eventType.calIdWorkflows,
+    }),
   });
 
   const isOrgEventType = !!eventTypeObject.team?.parentId;
@@ -425,7 +429,7 @@ export const getEventTypeByIdForCalId = async ({
     ),
   };
 
-  // backwards compat
+  // backwards compats
   if (eventType.users.length === 0 && !(eventType as any).calIdTeam) {
     const fallbackUser = await prisma.user.findUnique({
       where: {
@@ -485,7 +489,11 @@ export const getEventTypeByIdForCalId = async ({
     users: eventTypeUsers,
     periodStartDate: eventType.periodStartDate?.toString() ?? null,
     periodEndDate: eventType.periodEndDate?.toString() ?? null,
-    bookingFields: getBookingFieldsWithSystemFields({ ...eventType, isOrgTeamEvent }),
+    bookingFields: getBookingFieldsWithSystemFields({
+      ...eventType,
+      isOrgTeamEvent,
+      workflows: eventType.calIdWorkflows,
+    }),
   });
 
   const isOrgEventType = !!(eventTypeObject as any).calIdTeam?.parentId;

--- a/packages/trpc/server/routers/viewer/workflows/util.calid.ts
+++ b/packages/trpc/server/routers/viewer/workflows/util.calid.ts
@@ -11,7 +11,7 @@ import type { z } from "zod";
 
 import { SMS_REMINDER_NUMBER_FIELD } from "@calcom/features/bookings/lib/SystemField";
 import {
-  getSmsReminderNumberField,
+  // getSmsReminderNumberField,
   getSmsReminderNumberSource,
 } from "@calcom/features/bookings/lib/getBookingFields";
 import { removeBookingField, upsertBookingField } from "@calcom/features/eventtypes/lib/bookingFieldsManager";
@@ -302,7 +302,7 @@ export async function upsertCalIdSmsReminderFieldForEventTypes({
   // For CalId workflows, we only handle event types (no team level complexity)
   for (const eventTypeId of activeOn) {
     await upsertBookingField(
-      getSmsReminderNumberField(),
+      //getSmsReminderNumberField(),
       getSmsReminderNumberSource({
         workflowId,
         isSmsReminderNumberRequired,

--- a/packages/trpc/server/routers/viewer/workflows/util.ts
+++ b/packages/trpc/server/routers/viewer/workflows/util.ts
@@ -11,7 +11,7 @@ import type { z } from "zod";
 
 import { SMS_REMINDER_NUMBER_FIELD } from "@calcom/features/bookings/lib/SystemField";
 import {
-  getSmsReminderNumberField,
+  //getSmsReminderNumberField,
   getSmsReminderNumberSource,
 } from "@calcom/features/bookings/lib/getBookingFields";
 import { removeBookingField, upsertBookingField } from "@calcom/features/eventtypes/lib/bookingFieldsManager";
@@ -306,7 +306,7 @@ export async function upsertSmsReminderFieldForEventTypes({
 
   for (const eventTypeId of allEventTypeIds) {
     await upsertBookingField(
-      getSmsReminderNumberField(),
+      //getSmsReminderNumberField(),
       getSmsReminderNumberSource({
         workflowId,
         isSmsReminderNumberRequired,


### PR DESCRIPTION
## What does this PR do?
- Removes the SMS phone field.
- Merges its functionality into the default phone field.
- If an SMS workflow is enabled, the toggle on the Event Type (Advanced page) is disabled.
- Ensures WhatsApp/SMS reminders are sent successfully.
- Displays the correct phone field name on the Calendar Event page.

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

