### PR TITLE
Fixed Brand bg disappearing from Insights tab on Routing and Workflows

### DIFF
--- a/packages/features/shell/navigation/Navigation.tsx
+++ b/packages/features/shell/navigation/Navigation.tsx
@@ -80,7 +80,7 @@ const getNavigationItems = (orgBranding: OrganizationBranding): NavigationItemTy
     name: "insights",
     href: "/insights/bookings",
     icon: "chart-no-axes-column-increasing",
-    isCurrent: ({ pathname: path, item }) => path?.startsWith(item.href) ?? false,
+    isCurrent: ({ pathname: path }) => path?.startsWith("/insights") ?? false,
     moreOnMobile: true,
   },
   {


### PR DESCRIPTION
## What does this PR do?

Fixes Brand bg disappearing when Insights tab is active on Routing and Workflows.
