### PR TITLE
team events on teams public page

### DIFF
--- a/apps/web/lib/team/[slug]/getCalIdServerSideProps.tsx
+++ b/apps/web/lib/team/[slug]/getCalIdServerSideProps.tsx
@@ -97,9 +97,7 @@ export const getCalIdServerSideProps = async (context: GetServerSidePropsContext
             },
           },
         },
-        orderBy: {
-          id: "asc",
-        },
+        orderBy: [{ position: "desc" }, { id: "asc" }],
       },
     },
   });


### PR DESCRIPTION
## What does this PR do?
- Persist rearranged team events on teams public page.
- Updated getCalIdServerSideProps to include orderBy: position: "desc".

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://cal.com/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.