### PR TITLE
chore:kept triggered workflow records in db

### DIFF
--- a/packages/app-store/office365video/lib/VideoApiAdapter.ts
+++ b/packages/app-store/office365video/lib/VideoApiAdapter.ts
@@ -216,11 +216,7 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
       return Promise.resolve([]);
     },
     createMeeting: async (event: CalendarEvent): Promise<VideoCallData> => {
-      console.log("=======>createMeeting: ");
-
       const url = `${await getUserEndpoint()}/onlineMeetings`;
-      console.log("urllllllllllll: ", url);
-      console.log("translateEvent(event): ", translateEvent(event));
       const resultString = await auth
         .requestRaw({
           url,
@@ -232,6 +228,8 @@ const TeamsVideoApiAdapter = (credential: CredentialForCalendarServiceWithTenant
         .then(handleErrorsRaw);
 
       const resultObject = JSON.parse(resultString);
+
+      console.log("__resultObject", resultObject);
 
       if (!resultObject.id || !resultObject.joinUrl || !resultObject.joinWebUrl) {
         throw new HttpError({

--- a/packages/calid/modules/workflows/api/cron/queueEmailReminder.ts
+++ b/packages/calid/modules/workflows/api/cron/queueEmailReminder.ts
@@ -10,7 +10,7 @@ import logger from "@calcom/lib/logger";
 import { getTranslation } from "@calcom/lib/server/i18n";
 import { getTimeFormatStringFromUserTimeFormat } from "@calcom/lib/timeFormat";
 import prisma from "@calcom/prisma";
-import { SchedulingType, WorkflowActions, WorkflowMethods, WorkflowTemplates } from "@calcom/prisma/enums";
+import { SchedulingType, WorkflowActions, WorkflowTemplates } from "@calcom/prisma/enums";
 import { bookingMetadataSchema } from "@calcom/prisma/zod-utils";
 
 import type { PartialCalIdWorkflowReminder } from "../../config/types";
@@ -22,18 +22,18 @@ import emailReminderTemplate from "../../templates/email/reminder";
 import emailThankYouTemplate from "../../templates/email/thankYouTemplate";
 import { getAllRemindersToCancel, getAllUnscheduledReminders } from "../../utils/getWorkflows";
 
-const removePastNotifications = async (): Promise<void> => {
-  await prisma.calIdWorkflowReminder.deleteMany({
-    where: {
-      method: WorkflowMethods.EMAIL,
-      scheduledDate: {
-        lte: dayjs().toISOString(),
-      },
-      scheduled: false,
-      OR: [{ cancelled: null }, { cancelled: false }],
-    },
-  });
-};
+// const removePastNotifications = async (): Promise<void> => {
+//   await prisma.calIdWorkflowReminder.deleteMany({
+//     where: {
+//       method: WorkflowMethods.EMAIL,
+//       scheduledDate: {
+//         lte: dayjs().toISOString(),
+//       },
+//       scheduled: false,
+//       OR: [{ cancelled: null }, { cancelled: false }],
+//     },
+//   });
+// };
 
 const processCancelledNotifications = async (): Promise<void> => {
   const notificationsToCancel: { referenceId: string | null; id: number }[] = await getAllRemindersToCancel();
@@ -458,7 +458,8 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ message: "No SendGrid API key or email" }, { status: 405 });
     }
 
-    await removePastNotifications();
+    //preventing removal of past notifications
+    // await removePastNotifications();
     await processCancelledNotifications();
 
     const pendingNotifications: PartialCalIdWorkflowReminder[] = await processNotificationScheduling();

--- a/packages/calid/modules/workflows/api/cron/queueWhatsappReminder.ts
+++ b/packages/calid/modules/workflows/api/cron/queueWhatsappReminder.ts
@@ -9,18 +9,18 @@ import * as twilio from "../../providers/twilio";
 import type { PartialCalIdWorkflowReminder } from "../../utils/getWorkflows";
 import { select } from "../../utils/getWorkflows";
 
-const removeExpiredNotifications = async (): Promise<void> => {
-  await prisma.calIdWorkflowReminder.deleteMany({
-    where: {
-      method: WorkflowMethods.WHATSAPP,
-      scheduledDate: {
-        lte: dayjs().toISOString(),
-      },
-      scheduled: false,
-      OR: [{ cancelled: null }, { cancelled: false }],
-    },
-  });
-};
+// const removeExpiredNotifications = async (): Promise<void> => {
+//   await prisma.calIdWorkflowReminder.deleteMany({
+//     where: {
+//       method: WorkflowMethods.WHATSAPP,
+//       scheduledDate: {
+//         lte: dayjs().toISOString(),
+//       },
+//       scheduled: false,
+//       OR: [{ cancelled: null }, { cancelled: false }],
+//     },
+//   });
+// };
 
 const fetchPendingMessages = async () => {
   return prisma.calIdWorkflowReminder.findMany({
@@ -29,6 +29,7 @@ const fetchPendingMessages = async () => {
       scheduled: false,
       scheduledDate: {
         lte: dayjs().add(7, "day").toISOString(),
+        gte: dayjs().toISOString(),
       },
       OR: [{ cancelled: null }, { cancelled: false }],
     },
@@ -126,6 +127,7 @@ const executeCancellationProcess = async (): Promise<void> => {
       cancelled: true,
       scheduledDate: {
         lte: dayjs().add(1, "hour").toISOString(),
+        gte: dayjs().toISOString(),
       },
     },
   });
@@ -164,7 +166,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ message: "Not authenticated" }, { status: 401 });
     }
 
-    await removeExpiredNotifications();
+    // await removeExpiredNotifications();
     await executeCancellationProcess();
 
     const scheduledMessagesCount = await processMessageQueue();

--- a/packages/calid/modules/workflows/utils/getWorkflows.ts
+++ b/packages/calid/modules/workflows/utils/getWorkflows.ts
@@ -111,6 +111,7 @@ export async function getAllRemindersToCancel(): Promise<RemindersToCancelType[]
     scheduled: true,
     scheduledDate: {
       lte: dayjs().add(1, "hour").toISOString(),
+      gte: dayjs().toISOString(),
     },
   };
 
@@ -207,6 +208,7 @@ export async function getAllUnscheduledReminders(): Promise<PartialCalIdWorkflow
     scheduled: false,
     scheduledDate: {
       lte: dayjs().add(2, "hour").toISOString(),
+      gte: dayjs().toISOString(),
     },
     OR: [{ cancelled: null }, { cancelled: false }],
   };


### PR DESCRIPTION

1.  Previously, processed workflow records were removed from the database. We now retain them for future reference and analytics
2. Also have updated the workflow-related queries accordingly to ensure they only fetch upcoming records