### PR TITLE
Always set completed onboarding from db

### DIFF
--- a/packages/trpc/server/routers/viewer/me/calid/get.handler.ts
+++ b/packages/trpc/server/routers/viewer/me/calid/get.handler.ts
@@ -53,7 +53,7 @@ export const getHandler = async ({ ctx, input }: MeOptions) => {
     },
   });
 
-  let completedOnboarding = !!userWithExtraFields?.completedOnboarding;
+  let completedOnboarding = userWithExtraFields?.completedOnboarding ?? false;
 
   let passwordAdded = false;
 


### PR DESCRIPTION
Update me/calid_get query to take completedOnboarding from db always.

Previous fix for setting the completedOnboarding inside session doesn't properly update the cookies and once the app memory is reset value is again taken from cookies and is outdated.
