### PR TITLE
fix: resolve invalid returnTo in MS Teams OAuth state

### DIFF
--- a/packages/app-store/office365video/components/InstallAppButton.tsx
+++ b/packages/app-store/office365video/components/InstallAppButton.tsx
@@ -11,17 +11,16 @@ import AccountDialog from "./AccountDialog";
 export default function InstallAppButton(props: InstallAppButtonProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const mutation = useAddAppMutation(null);
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
+    const returnTo = await getAppOnboardingUrl({
+      slug: "msteams",
+      step: AppOnboardingSteps.EVENT_TYPES_STEP,
+    });
     mutation.mutate({
       type: "office365_video",
       variant: "conferencing",
       slug: "msteams",
-      returnTo:
-        WEBAPP_URL +
-        getAppOnboardingUrl({
-          slug: "msteams",
-          step: AppOnboardingSteps.EVENT_TYPES_STEP,
-        }),
+      returnTo: WEBAPP_URL + returnTo,
     });
   };
 


### PR DESCRIPTION
Fixes MS Teams video installation by resolving the returnTo value before encoding OAuth state. Previously, an unresolved Promise was being stringified, resulting in an invalid URL during the callback.