### PR TITLE
Set member's default location as default for managed events

### DIFF
--- a/packages/calid/modules/event-types/components/tabs/event-types-setup.tsx
+++ b/packages/calid/modules/event-types/components/tabs/event-types-setup.tsx
@@ -625,6 +625,8 @@ export const EventSetup = (props: EventSetupTabProps) => {
           render={() => (
             <Locations
               showAppStoreLink={true}
+              isManagedEventType={isManagedEventType}
+              isChildrenManagedEventType={isManagedEventType}
               disableLocationProp={fieldPermissions.getFieldState("locations").isDisabled}
               getValues={formMethods.getValues as unknown as UseFormGetValues<LocationFormValues>}
               setValue={formMethods.setValue as unknown as UseFormSetValue<LocationFormValues>}


### PR DESCRIPTION
Closes #399

`Locations` component wasn't getting passed the prop `isManagedEventType`, which it checks to set the default `Member's default location` for managed events.