### PR TITLE
400 show emailsmswhatsapp status for default and workflows templates in bookings

### DIFF
--- a/packages/trpc/server/routers/viewer/bookings/get.handler.ts
+++ b/packages/trpc/server/routers/viewer/bookings/get.handler.ts
@@ -211,18 +211,24 @@ function resolveWorkflowStepStatus(
 
   // 2. Check workflowReminder
   if (workflowReminder) {
+    const parsedScheduledDate = parseUtcTimestamp(workflowReminder.scheduledDate);
+    const currentTime = Date.now();
+
+    if (workflowReminder.scheduled && parsedScheduledDate <= currentTime) {
+      return "DELIVERED";
+    }
     if (workflowReminder.cancelled) {
       return "CANCELLED";
     }
-
-    if (workflowReminder.scheduled) {
-      return parseUtcTimestamp(workflowReminder.scheduledDate) > Date.now() ? "QUEUED" : "DELIVERED";
+    if (workflowReminder.scheduled && parsedScheduledDate > currentTime) {
+      return "QUEUED";
     }
   }
 
   // 3. Default to QUEUED
   return "QUEUED";
 }
+
 export async function getBookings({
   user,
   prisma,


### PR DESCRIPTION
1. if reminder was scheduled and scheduledDate is in past we will mark it as "Delivered" no matter the Cancel status,because if successfully cancelled we mark the "scheduled" as false