### PR TITLE
fix: save business type (designation) to user metadata during onboarding

### DIFF
--- a/apps/web/components/getting-started/steps-views/UserSettings.tsx
+++ b/apps/web/components/getting-started/steps-views/UserSettings.tsx
@@ -107,6 +107,7 @@ const UserSettings = (props: IUserSettingsProps) => {
     mutation.mutate({
       metadata: {
         currentOnboardingStep: "connected-calendar",
+        designation: selectedBusiness || undefined,
       },
       name: data.name,
       username: data.username,

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -376,6 +376,7 @@ export const userMetadata = z
       })
       .optional(),
     currentOnboardingStep: z.string().optional(),
+    designation: z.string().optional(),
     gettingStartedActions: z
       .object({
         viewPublicPage: z.boolean().optional().default(false),

--- a/packages/trpc/server/routers/viewer/me/updateProfile.schema.ts
+++ b/packages/trpc/server/routers/viewer/me/updateProfile.schema.ts
@@ -10,6 +10,7 @@ export const updateUserMetadataAllowedKeys = z.object({
   defaultBookerLayouts: bookerLayouts.optional(),
   currentOnboardingStep: z.string().optional(),
   phoneNumber: z.string().optional(),
+  designation: z.string().optional(),
 });
 
 export const ZUpdateProfileInputSchema = z.object({


### PR DESCRIPTION
## What does this PR do?

Fixes business type selection not being saved during onboarding.

**Problem**: Users select their business type (Founder, Freelancer, etc.) in Step 1 of onboarding, but it's not saved to the database.

**Solution**: Added `designation` field to metadata schema and included it in the onboarding form submission.

## Changes Made

- Added `designation` to [userMetadata](cci:2://file:///Users/onehash1/Cal-ID/packages/prisma/zod-utils.ts:413:0-413:60) schema in [zod-utils.ts](cci:7://file:///Users/onehash1/Cal-ID/packages/prisma/zod-utils.ts:0:0-0:0)
- Added `designation` to allowed keys in [updateProfile.schema.ts](cci:7://file:///Users/onehash1/Cal-ID/packages/trpc/server/routers/viewer/me/updateProfile.schema.ts:0:0-0:0)
- Updated [UserSettings.tsx](cci:7://file:///Users/onehash1/Cal-ID/apps/web/components/getting-started/steps-views/UserSettings.tsx:0:0-0:0) to send `designation` in mutation

## How to Test

1. Run `yarn db-studio` and set user's `completedOnboarding` to `false`
2. Go to `/getting-started/user-settings`
3. Select a business type and click "Next Step"
4. Verify `metadata.designation` is saved in Prisma Studio