### PR TITLE
Fix/session timeout updates

### DIFF
--- a/apps/web/modules/settings/security/password-view.tsx
+++ b/apps/web/modules/settings/security/password-view.tsx
@@ -50,7 +50,7 @@ const SkeletonLoader = () => {
 };
 
 const PasswordView = ({ user }: PasswordViewProps) => {
-  const { data } = useSession();
+  const { data, update } = useSession();
   const { t } = useLocale();
   const utils = trpc.useUtils();
   const metadata = userMetadataSchema.safeParse(user?.metadata);
@@ -59,7 +59,8 @@ const PasswordView = ({ user }: PasswordViewProps) => {
   const [sessionTimeout, setSessionTimeout] = useState<number | undefined>(initialSessionTimeout);
 
   const sessionMutation = trpc.viewer.me.calid_updateProfile.useMutation({
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
+      await update();
       triggerToast(t("session_timeout_changed"), "success");
       formMethods.reset(formMethods.getValues());
       setSessionTimeout(data.metadata?.sessionTimeout);
@@ -281,7 +282,7 @@ const PasswordView = ({ user }: PasswordViewProps) => {
                     loading={sessionMutation.isPending}
                     onClick={() => {
                       sessionMutation.mutate({
-                        metadata: { ...metadata, sessionTimeout },
+                        metadata: { ...metadata.data, sessionTimeout },
                       });
                       formMethods.clearErrors("apiError");
                     }}


### PR DESCRIPTION
## What does this PR do?

Fixes two issues with the Session Timeout feature in Security Settings.

**1. Fixes "Lazy Update" Issue**
- Previously, changing the session timeout setting updated the database but not the current browser session cookie.
- Users had to log out and back in for the new timeout to take effect.
- **Fix**: Added `await update()` from `next-auth` to force an immediate session refresh upon save.

**2. Fixes Metadata Data Structure**
- Previously, the code was spreading the Zod result object (`{ success: true, data: ... }`) into the metadata field.
- **Fix**: Changed to efficiently spread `...metadata.data`.

## How to Test

1. Go to **Settings -> Security -> Password**.
2. Change "Timeout session after" to **5 mins**.
3. Verify the toast "Session timeout updated" appears.
4. Wait 5 minutes (or check cookies) to verify the new timeout is respected immediately.