### PR TITLE
Fix: Tooltip changes from Copy to Copied on click

### DIFF
--- a/packages/calid/ui/components/badge.tsx
+++ b/packages/calid/ui/components/badge.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@calid/features/lib/cn";
 import { Icon, type IconName } from "@calid/features/ui/components/icon/Icon";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
@@ -91,6 +92,7 @@ export const Badge = function Badge(props: BadgeProps) {
       setTimeout(() => setIsCopied(false), 1500);
     });
   };
+
   const handleRedirectUrl = (e: React.MouseEvent) => {
     e.stopPropagation();
 
@@ -117,17 +119,28 @@ export const Badge = function Badge(props: BadgeProps) {
       {children}
       {publicUrl && (
         <div className="ml-1 flex items-center">
-          <Tooltip content={isCopied ? t("copied") : t("copy")}>
-            <Button
-              variant="icon"
-              StartIcon="copy"
-              color="minimal"
-              className="border-none"
-              size="xs"
-              onClick={handleCopyUrl}
-              data-testid="copy-url-button"
-            />
-          </Tooltip>
+          <TooltipPrimitive.Provider delayDuration={300}>
+            <TooltipPrimitive.Root open={isCopied ? true : undefined}>
+              <TooltipPrimitive.Trigger asChild>
+                <Button
+                  variant="icon"
+                  StartIcon="copy"
+                  color="minimal"
+                  className="border-none"
+                  size="xs"
+                  onClick={handleCopyUrl}
+                  data-testid="copy-url-button"
+                />
+              </TooltipPrimitive.Trigger>
+              <TooltipPrimitive.Content
+                sideOffset={4}
+                side="top"
+                className="z-50 overflow-hidden rounded-md bg-black px-2 py-1 text-xs font-medium text-white shadow-[0_20px_25px_-5px_rgb(0_0_0_/_0.1),_0_10px_10px_-5px_rgb(0_0_0_/_0.04)]">
+                {isCopied ? t("copied") : t("copy")}
+              </TooltipPrimitive.Content>
+            </TooltipPrimitive.Root>
+          </TooltipPrimitive.Provider>
+
           <Tooltip content={t("preview")}>
             <Button
               variant="icon"


### PR DESCRIPTION
## Description
Fixed tooltip behavior on the copy icon in the event-type page. The tooltip now correctly changes from "Copy" to "Copied!" when clicked, while maintaining normal hover functionality.

## Changes
- Added `@radix-ui/react-tooltip` import for controlled tooltip behavior
- Modified tooltip to force open state when copy action occurs
- Tooltip shows "Copy" on hover and changes to "Copied!" for 1.5s after clicking

## Issue
Fixes #595

## Testing
1. Navigate to Event Types page
2. Hover over the copy icon next to the public URL - tooltip shows "Copy"
3. Click the copy icon - tooltip immediately changes to "Copied!"
4. Wait 1.5s - tooltip reverts to "Copy"
5. Repeat multiple times to verify consistent behavior

## Files Changed
- `packages/calid/ui/components/badge.tsx`