### PR TITLE
fix: location options label in calendar page

### DIFF
--- a/apps/web/public/static/locales/ar/common.json
+++ b/apps/web/public/static/locales/ar/common.json
@@ -2477,7 +2477,6 @@
   "insights_user_filter": "المستخدم: {{userName}}",
   "insights_subtitle": "التحليلات ومقاييس الأداء لأنشطة الجدولة الخاصة بك",
   "location_options": "خيارات الموقع {{locationCount}}",
-  "location_options_label": "خيارات الموقع",
   "custom_plan": "الخطة المخصصة",
   "email_embed": "البريد الإلكتروني المضمن",
   "add_times_to_your_email": "حدّد بعض الفترات المتاحة وأدرجها في رسالتك الإلكترونية",

--- a/apps/web/public/static/locales/az/common.json
+++ b/apps/web/public/static/locales/az/common.json
@@ -2477,7 +2477,6 @@
   "insights_user_filter": "İstifadəçi: {{userName}}",
   "insights_subtitle": "Planlaşdırma fəaliyyətləriniz üçün analitika və performans göstəriciləri",
   "location_options": "{{locationCount}} məkan seçimi",
-  "location_options_label": "Məkan seçimləri",
   "custom_plan": "Xüsusi Plan",
   "email_embed": "Email Əlavəsi",
   "add_times_to_your_email": "Mövcud vaxtları seçin və Email-ə əlavə edin",

--- a/apps/web/public/static/locales/bg/common.json
+++ b/apps/web/public/static/locales/bg/common.json
@@ -2477,7 +2477,6 @@
   "insights_user_filter": "Потребител: {{userName}}",
   "insights_subtitle": "Анализи и показатели за ефективност на вашите дейности по планиране",
   "location_options": "{{locationCount}} опции за локация",
-  "location_options_label": "Опции за местоположение",
   "custom_plan": "Персонализиран план",
   "email_embed": "Вграждане в имейл",
   "add_times_to_your_email": "Изберете няколко свободни часа и ги вградете във вашия имейл",

--- a/apps/web/public/static/locales/bn/common.json
+++ b/apps/web/public/static/locales/bn/common.json
@@ -2477,7 +2477,6 @@
   "insights_user_filter": "ব্যবহারকারী: {{userName}}",
   "insights_subtitle": "আপনার শিডিউলিং কার্যক্রমের জন্য অ্যানালিটিক্স এবং পারফরম্যান্স মেট্রিক্স",
   "location_options": "{{locationCount}} অবস্থান বিকল্প",
-  "location_options_label": "লোকেশন অপশন",
   "custom_plan": "কাস্টম পরিকল্পনা",
   "email_embed": "ইমেল এম্বেড",
   "add_times_to_your_email": "কয়েকটি উপলভ্য সময় নির্বাচন করুন এবং সেগুলি আপনার ইমেলটিতে এম্বেড করুন",

--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -2484,7 +2484,6 @@
   "insights_user_filter": "User: {{userName}}",
   "insights_subtitle": "Analytics and performance metrics for your scheduling activities",
   "location_options": "{{locationCount}} location options",
-  "location_options_label": "Location options",
   "custom_plan": "Custom Plan",
   "email_embed": "Email Embed",
   "add_times_to_your_email": "Select a few available times and embed them in your Email",

--- a/packages/features/bookings/components/event-meta/AvailableEventLocations.tsx
+++ b/packages/features/bookings/components/event-meta/AvailableEventLocations.tsx
@@ -100,44 +100,25 @@ export function AvailableEventLocations({ locations }: { locations: LocationObje
 
   return filteredLocations.length > 1 ? (
     <div className="flex flex-col">
-      <div className="flex flex-row items-center text-sm font-medium">
-        {isPlatform ? (
-          <Icon name="map-pin" className={classNames("me-[10px] h-4 w-4 opacity-70 dark:invert")} />
-        ) : (
-          <img
-            src="/map-pin-dark.svg"
-            className={classNames("me-[10px] h-4 w-4 opacity-70 dark:invert")}
-            alt="map-pin"
-          />
-        )}
+      <Tooltip content={<RenderLocationTooltip locations={locations} />}>
+        <div className="flex flex-row items-center text-sm font-medium">
+          {isPlatform ? (
+            <Icon name="map-pin" className={classNames("me-[10px] h-4 w-4 opacity-70 dark:invert")} />
+          ) : (
+            <img
+              src="/map-pin-dark.svg"
+              className={classNames("me-[10px] h-4 w-4 opacity-70 dark:invert")}
+              alt="map-pin"
+            />
+          )}
 
-        <p className="line-clamp-1">
-          {/* {t("location_options", {
+          <p className="text-default line-clamp-1">
+            {t("location_options", {
               locationCount: filteredLocations.length,
-            })} */}
-          {t("location_options_label")}
-        </p>
-      </div>
-      <div className="mt-2 flex flex-row items-center">
-        {locations
-          .map((loc) => getEventLocationType(loc.type))
-          .map((eventLocationType) => (
-            <div className="border-subtle me-2 flex flex-row justify-center rounded-2xl border py-1 pl-2">
-              {eventLocationType.iconUrl === "/link.svg" ? (
-                <Icon name="link" className="text-default h-4 w-4 ltr:mr-[10px] rtl:ml-[10px]" />
-              ) : (
-                <RenderIcon eventLocationType={eventLocationType} isTooltip={false} />
-              )}
-            </div>
-          ))}
-        <div className="flex-1" />
-
-        <Tooltip content={<RenderLocationTooltip locations={locations} />}>
-          <p className="line-clamp-1">
-            <Icon name="info" className="h-4 w-4" />
+            })}
           </p>
-        </Tooltip>
-      </div>
+        </div>
+      </Tooltip>
     </div>
   ) : filteredLocations.length === 1 ? (
     <div className="text-default mr-6 flex w-full flex-col space-y-4 break-words text-sm rtl:mr-2">


### PR DESCRIPTION
## What does this PR do?

Fixes location options label coming as **location_options_label** instead of **{count} location options** in booking calendar view if user has allowed multiple location for the event-type.