### PR TITLE
fix: Checkbox field url field not focusing

### DIFF
--- a/packages/calid/ui/components/dialog.tsx
+++ b/packages/calid/ui/components/dialog.tsx
@@ -71,12 +71,18 @@ interface DialogContentProps
   extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>,
     VariantProps<typeof dialogContentVariants> {
   showCloseButton?: boolean;
+  forceOverlayWhenNoModal?: boolean;
 }
 
 const DialogContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Content>, DialogContentProps>(
-  ({ className, children, size, showCloseButton = false, ...props }, ref) => (
+  ({ className, children, size, showCloseButton = false, forceOverlayWhenNoModal, ...props }, ref) => (
     <DialogPortal>
-      <DialogOverlay />
+      {forceOverlayWhenNoModal ? (
+        <div className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 pointer-events-none fixed inset-0 z-50 bg-black/60 backdrop-blur-sm" />
+      ) : (
+        <DialogOverlay />
+      )}
+
       <DialogPrimitive.Content
         ref={ref}
         className={cn(dialogContentVariants({ size }), className)}

--- a/packages/features/form-builder/FormBuilder.tsx
+++ b/packages/features/form-builder/FormBuilder.tsx
@@ -634,8 +634,14 @@ function FieldEditDialog({
   const hidden = fieldForm.getValues("hidden");
 
   return (
-    <Dialog open={dialog.isOpen} onOpenChange={onOpenChange}>
-      <DialogContent size="md" className="max-h-none" data-testid="edit-field-dialog" enableOverflow={true}>
+    <Dialog open={dialog.isOpen} onOpenChange={onOpenChange} modal={false}>
+      <DialogContent
+        size="md"
+        className="max-h-none"
+        data-testid="edit-field-dialog"
+        enableOverflow={true}
+        forceOverlayWhenNoModal={true} // ← Add this to keep the backdrop
+      >
         <DialogHeader>
           <DialogTitle>{t("add_a_booking_question")}</DialogTitle>
           <DialogDescription>{t("booking_questions_description")}</DialogDescription>

--- a/packages/ui/components/editor/plugins/ToolbarPlugin.tsx
+++ b/packages/ui/components/editor/plugins/ToolbarPlugin.tsx
@@ -115,7 +115,10 @@ function FloatingLinkEditor({ editor }: { editor: LexicalEditor }) {
       }
 
       setLastSelection(selection);
-    } else if (!activeElement || activeElement.className !== "link-input") {
+    } else if (
+      !activeElement ||
+      (activeElement.className !== "link-input" && !editorElem.contains(activeElement)) 
+    ) {
       positionEditorElement(editorElem, null);
       setLastSelection(null);
       setEditMode(false);
@@ -123,6 +126,34 @@ function FloatingLinkEditor({ editor }: { editor: LexicalEditor }) {
     }
 
     return true;
+  }, [editor]);
+
+  // Add click outside handler
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      const editorElem = editorRef.current;
+      const target = event.target as Node;
+
+      // Close if clicking outside the link editor
+      if (editorElem && !editorElem.contains(target)) {
+        // Check if click is inside the lexical editor root
+        const rootElement = editor.getRootElement();
+        const isClickInEditor = rootElement && rootElement.contains(target);
+
+        if (!isClickInEditor) {
+          // Clicked outside both link editor and lexical editor - close it
+          positionEditorElement(editorElem, null);
+          setLastSelection(null);
+          setEditMode(false);
+          setLinkUrl("");
+        }
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
   }, [editor]);
 
   useEffect(() => {

--- a/packages/ui/components/form/checkbox/Checkbox.tsx
+++ b/packages/ui/components/form/checkbox/Checkbox.tsx
@@ -95,7 +95,7 @@ const CheckboxField = forwardRef<HTMLInputElement, Props>(
                 {descriptionAsSafeHtml ? (
                   <span
                     className={classNames(
-                      "text-default ml-2 text-sm",
+                      "text-default ml-2 text-sm [&_a]:text-blue-500",
                       !label && "font-medium",
                       rest.descriptionClassName
                     )}


### PR DESCRIPTION
Closes #659 

1. There was an issue where checkbox dialog wasn't being focused.
2. Handled the url dialog close, which was only dismissing when clicking inside the editor, now it will dismiss on clicking anywhere outside the url dialog