### PR TITLE
Fix for missing fields when scheduling from cron

### DIFF
--- a/packages/calid/modules/workflows/api/cron/queueWhatsappReminder.ts
+++ b/packages/calid/modules/workflows/api/cron/queueWhatsappReminder.ts
@@ -89,6 +89,8 @@ const processMessageQueue = async (): Promise<number> => {
         {
           uid: message.booking.uid,
           title: message.booking.title,
+          location: message.booking.location,
+          metadata: message.booking.metadata,
           additionalNotes: message.booking.description,
           eventTypeId: message.booking.eventTypeId,
           eventType: message.booking.eventType,
@@ -140,11 +142,11 @@ const processMessageQueue = async (): Promise<number> => {
         data: {
           action: message.workflowStep.action,
           eventTypeId: message.booking.eventTypeId,
-          workflowId: message.workflowStep.workflowId,
-          workflowStepId: message.workflowStepId,
+          workflowId: message.workflowStep.workflow.id,
+          workflowStepId: message.workflowStep.id,
           recipientNumber,
           reminderId: message.id,
-          bookingUid: message.bookingUid,
+          bookingUid: message.booking.uid,
           scheduledDate: scheduledDate.toISOString(),
           variableData: templateVariables,
           userId: workflowUserId,

--- a/packages/calid/modules/workflows/utils/getWorkflows.ts
+++ b/packages/calid/modules/workflows/utils/getWorkflows.ts
@@ -6,7 +6,7 @@ import { WorkflowMethods } from "@calcom/prisma/enums";
 import type { CalIdWorkflow, CalIdWorkflowStep } from "../config/types";
 
 type PartialCalIdWorkflowStep =
-  | (Partial<CalIdWorkflowStep> & { workflow: { userId?: number; calIdTeamId?: number } })
+  | (Partial<CalIdWorkflowStep> & { workflow: { id?: number, userId?: number; calIdTeamId?: number } })
   | null;
 
 type Booking = Prisma.BookingGetPayload<{
@@ -139,6 +139,7 @@ export const select: Prisma.CalIdWorkflowReminderSelect = {
   referenceId: true,
   workflowStep: {
     select: {
+      id: true,
       action: true,
       sendTo: true,
       reminderBody: true,


### PR DESCRIPTION
Fixes missing location and meeting url field when scheduled a meta template from cron.
Fixes booking uid not appearing in logs.