### PR TITLE
admin users non-ee module

### DIFF
--- a/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/users/[id]/edit/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/users/[id]/edit/page.tsx
@@ -1,9 +1,8 @@
+import AdminUserEditPage from "@calid/features/modules/admin/pages/user-edit";
 import { type Params } from "app/_types";
 import { _generateMetadata, getTranslate } from "app/_utils";
 import { z } from "zod";
 
-import LicenseRequired from "@calcom/features/ee/common/components/LicenseRequired";
-import { UsersEditView } from "@calcom/features/ee/users/pages/users-edit-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 import { UserRepository } from "@calcom/lib/server/repository/user";
 import prisma from "@calcom/prisma";
@@ -39,15 +38,11 @@ const Page = async ({ params }: { params: Params }) => {
 
   if (!input.success) throw new Error("Invalid access");
 
-  const userRepo = new UserRepository(prisma);
-  const user = await userRepo.adminFindById(input.data.id);
   const t = await getTranslate();
 
   return (
     <SettingsHeader title={t("editing_user")} description={t("admin_users_edit_description")}>
-      <LicenseRequired>
-        <UsersEditView user={user} />
-      </LicenseRequired>
+      <AdminUserEditPage />
     </SettingsHeader>
   );
 };

--- a/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/users/add/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/users/add/page.tsx
@@ -1,6 +1,6 @@
+import AdminUserAddPage from "@calid/features/modules/admin/pages/user-add";
 import { _generateMetadata, getTranslate } from "app/_utils";
 
-import UsersAddView from "@calcom/features/ee/users/pages/users-add-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
 export const generateMetadata = async () =>
@@ -17,7 +17,7 @@ const Page = async () => {
 
   return (
     <SettingsHeader title={t("add_new_user")} description={t("admin_users_add_description")}>
-      <UsersAddView />
+      <AdminUserAddPage />
     </SettingsHeader>
   );
 };

--- a/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/users/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/users/page.tsx
@@ -1,7 +1,7 @@
+import AdminUsersListPage from "@calid/features/modules/admin/pages/users-list";
 import { Button } from "@calid/features/ui/components/button";
 import { _generateMetadata, getTranslate } from "app/_utils";
 
-import UsersListingView from "@calcom/features/ee/users/pages/users-listing-view";
 import SettingsHeader from "@calcom/features/settings/appDir/SettingsHeader";
 
 export const generateMetadata = async () =>
@@ -26,7 +26,7 @@ const Page = async () => {
           <Button href="/settings/admin/users/add">Add user</Button>
         </div>
       }>
-      <UsersListingView />
+      <AdminUsersListPage />
     </SettingsHeader>
   );
 };

--- a/packages/calid/modules/admin/components/AdminUserForm.tsx
+++ b/packages/calid/modules/admin/components/AdminUserForm.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { Controller, useForm, useWatch } from "react-hook-form";
+
+import { TimezoneSelect } from "@calcom/features/components/timezone-select";
+import { getUserAvatarUrl } from "@calcom/lib/getAvatarUrl";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { defaultLocaleOption, localeOptions } from "@calcom/lib/i18n";
+import { nameOfDay } from "@calcom/lib/weekday";
+import { Avatar } from "@calcom/ui/components/avatar";
+import { Button } from "@calcom/ui/components/button";
+import { EmailField, Form, Label, Select, TextField } from "@calcom/ui/components/form";
+import { ImageUploader } from "@calcom/ui/components/image-uploader";
+
+export type AdminUserFormValues = {
+  avatarUrl: string | null;
+  name: string;
+  username: string;
+  email: string;
+  bio: string | null;
+  locale: string;
+  timeZone: string;
+  timeFormat: number;
+  weekStart: string;
+  role: string;
+  identityProvider: string;
+};
+
+const identityProviderOptions = [
+  { value: "CAL", label: "CAL" },
+  { value: "GOOGLE", label: "GOOGLE" },
+  { value: "SAML", label: "SAML" },
+];
+
+const roleOptions = [
+  { value: "USER", label: "User" },
+  { value: "ADMIN", label: "Admin" },
+];
+
+export const AdminUserForm = ({
+  defaultValues,
+  localeProp = "en",
+  submitLabel = "Save",
+  onSubmit,
+}: {
+  defaultValues?: Partial<AdminUserFormValues>;
+  localeProp?: string;
+  submitLabel?: string;
+  onSubmit: (values: AdminUserFormValues) => void;
+}) => {
+  const { t } = useLocale();
+
+  const timeFormatOptions = [
+    { value: 12, label: t("12_hour") },
+    { value: 24, label: t("24_hour") },
+  ];
+
+  const weekStartOptions = [
+    { value: "Sunday", label: nameOfDay(localeProp, 0) },
+    { value: "Monday", label: nameOfDay(localeProp, 1) },
+    { value: "Tuesday", label: nameOfDay(localeProp, 2) },
+    { value: "Wednesday", label: nameOfDay(localeProp, 3) },
+    { value: "Thursday", label: nameOfDay(localeProp, 4) },
+    { value: "Friday", label: nameOfDay(localeProp, 5) },
+    { value: "Saturday", label: nameOfDay(localeProp, 6) },
+  ];
+
+  const resolvedLocale = defaultValues?.locale || defaultLocaleOption.value;
+
+  const form = useForm<AdminUserFormValues>({
+    defaultValues: {
+      avatarUrl: defaultValues?.avatarUrl ?? null,
+      name: defaultValues?.name ?? "",
+      username: defaultValues?.username ?? "",
+      email: defaultValues?.email ?? "",
+      bio: defaultValues?.bio ?? "",
+      locale: resolvedLocale,
+      timeZone: defaultValues?.timeZone ?? "",
+      timeFormat: defaultValues?.timeFormat ?? 12,
+      weekStart: defaultValues?.weekStart ?? "Monday",
+      role: defaultValues?.role ?? "USER",
+      identityProvider: defaultValues?.identityProvider ?? "CAL",
+    },
+  });
+
+  const baselineRef = useRef<AdminUserFormValues | null>(null);
+  const watchedValues = useWatch({ control: form.control });
+
+  const normalizeTimeZone = useCallback(
+    (timeZone: string | null | undefined) => (timeZone || "").replace("Asia/Calcutta", "Asia/Kolkata"),
+    []
+  );
+
+  const normalizeValues = useCallback(
+    (values: Partial<AdminUserFormValues> | undefined) => ({
+      avatarUrl: values?.avatarUrl ?? null,
+      name: values?.name ?? "",
+      username: values?.username ?? "",
+      email: values?.email ?? "",
+      bio: values?.bio ?? "",
+      locale: values?.locale ?? resolvedLocale,
+      timeZone: normalizeTimeZone(values?.timeZone),
+      timeFormat: values?.timeFormat ?? 12,
+      weekStart: values?.weekStart ?? "Monday",
+      role: values?.role ?? "USER",
+      identityProvider: values?.identityProvider ?? "CAL",
+    }),
+    [normalizeTimeZone, resolvedLocale]
+  );
+
+  useEffect(() => {
+    const normalized = normalizeValues(defaultValues);
+    baselineRef.current = normalized;
+    form.reset(normalized);
+  }, [defaultValues, form, normalizeValues]);
+
+  const isDirty = useMemo(() => {
+    const baseline = baselineRef.current;
+    if (!baseline) return false;
+    const current = normalizeValues(watchedValues);
+    return (
+      current.avatarUrl !== baseline.avatarUrl ||
+      current.name !== baseline.name ||
+      current.username !== baseline.username ||
+      current.email !== baseline.email ||
+      current.bio !== baseline.bio ||
+      current.locale !== baseline.locale ||
+      current.timeZone !== baseline.timeZone ||
+      current.timeFormat !== baseline.timeFormat ||
+      current.weekStart !== baseline.weekStart ||
+      current.role !== baseline.role ||
+      current.identityProvider !== baseline.identityProvider
+    );
+  }, [normalizeValues, watchedValues]);
+
+  return (
+    <Form form={form} className="space-y-4" handleSubmit={onSubmit}>
+      <div className="flex items-center">
+        <Controller
+          control={form.control}
+          name="avatarUrl"
+          render={({ field: { value, onChange } }) => (
+            <>
+              <Avatar
+                alt={form.getValues("name") || ""}
+                imageSrc={getUserAvatarUrl({ avatarUrl: value || undefined })}
+                size="lg"
+              />
+              <div className="ml-4">
+                <ImageUploader
+                  target="avatar"
+                  id="admin-avatar-upload"
+                  buttonMsg="Change avatar"
+                  handleAvatarChange={onChange}
+                  imageSrc={getUserAvatarUrl({ avatarUrl: value || undefined })}
+                />
+              </div>
+            </>
+          )}
+        />
+      </div>
+
+      <Controller
+        control={form.control}
+        name="role"
+        render={({ field: { onChange, value } }) => (
+          <div>
+            <Label className="text-default font-medium" htmlFor="role">
+              {t("role")}
+            </Label>
+            <Select
+              value={roleOptions.find((opt) => opt.value === value)}
+              options={roleOptions}
+              onChange={(option) => onChange(option?.value ?? "USER")}
+            />
+          </div>
+        )}
+      />
+
+      <Controller
+        control={form.control}
+        name="identityProvider"
+        render={({ field: { onChange, value } }) => (
+          <div>
+            <Label className="text-default font-medium" htmlFor="identityProvider">
+              {t("identity_provider")}
+            </Label>
+            <Select
+              value={identityProviderOptions.find((opt) => opt.value === value)}
+              options={identityProviderOptions}
+              onChange={(option) => onChange(option?.value ?? "CAL")}
+            />
+          </div>
+        )}
+      />
+
+      <TextField label={t("name")} placeholder="example" required {...form.register("name")} />
+      <TextField label={t("username")} placeholder="example" required {...form.register("username")} />
+      <EmailField label={t("email")} placeholder="user@example.com" required {...form.register("email")} />
+      <TextField label={t("about")} {...form.register("bio")} />
+
+      <Controller
+        control={form.control}
+        name="locale"
+        render={({ field: { onChange, value } }) => (
+          <div>
+            <Label className="text-default">{t("language")}</Label>
+            <Select
+              className="capitalize"
+              options={localeOptions}
+              value={localeOptions.find((option) => option.value === value)}
+              onChange={(option) => onChange(option?.value ?? defaultLocaleOption.value)}
+            />
+          </div>
+        )}
+      />
+
+      <Controller
+        control={form.control}
+        name="timeZone"
+        render={({ field: { value } }) => (
+          <div>
+            <Label className="text-default mt-8">{t("timezone")}</Label>
+            <TimezoneSelect
+              id="timezone"
+              value={value}
+              onChange={(event) => {
+                const nextValue = event?.value ?? "";
+                const baseline = baselineRef.current?.timeZone ?? "";
+                form.setValue("timeZone", nextValue, { shouldDirty: nextValue !== baseline });
+              }}
+            />
+          </div>
+        )}
+      />
+
+      <Controller
+        control={form.control}
+        name="timeFormat"
+        render={({ field: { value, onChange } }) => (
+          <div>
+            <Label className="text-default mt-8">{t("time_format")}</Label>
+            <Select
+              value={timeFormatOptions.find((opt) => opt.value === value)}
+              options={timeFormatOptions}
+              onChange={(option) => onChange(option?.value ?? 12)}
+            />
+          </div>
+        )}
+      />
+
+      <Controller
+        control={form.control}
+        name="weekStart"
+        render={({ field: { value, onChange } }) => (
+          <div>
+            <Label className="text-default mt-8">{t("start_of_week")}</Label>
+            <Select
+              value={weekStartOptions.find((opt) => opt.value === value)}
+              options={weekStartOptions}
+              onChange={(option) => onChange(option?.value ?? "Monday")}
+            />
+          </div>
+        )}
+      />
+
+      <Button type="submit" color="primary" disabled={!isDirty}>
+        {submitLabel}
+      </Button>
+    </Form>
+  );
+};

--- a/packages/calid/modules/admin/components/AdminUsersTable.tsx
+++ b/packages/calid/modules/admin/components/AdminUsersTable.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { keepPreviousData } from "@tanstack/react-query";
+import { signIn } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { getUserAvatarUrl } from "@calcom/lib/getAvatarUrl";
+import { useDebounce } from "@calcom/lib/hooks/useDebounce";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import { trpc } from "@calcom/trpc/react";
+import { Avatar } from "@calcom/ui/components/avatar";
+import { Badge } from "@calcom/ui/components/badge";
+import { Button } from "@calcom/ui/components/button";
+import {
+  ConfirmationDialogContent,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+} from "@calcom/ui/components/dialog";
+import { TextField } from "@calcom/ui/components/form";
+import { Icon } from "@calcom/ui/components/icon";
+import { DropdownActions, Table } from "@calcom/ui/components/table";
+import { showToast } from "@calcom/ui/components/toast";
+
+const { Cell, ColumnTitle, Header, Row } = Table;
+
+const FETCH_LIMIT = 25;
+
+export const AdminUsersTable = () => {
+  const { t } = useLocale();
+  const router = useRouter();
+  const tableContainerRef = useRef<HTMLDivElement>(null);
+  const utils = trpc.useUtils();
+
+  const [searchTerm, setSearchTerm] = useState("");
+  const debouncedSearchTerm = useDebounce(searchTerm, 500);
+
+  const [userToDelete, setUserToDelete] = useState<number | null>(null);
+  const [impersonateUser, setImpersonateUser] = useState<string | null>(null);
+  const [showImpersonateModal, setShowImpersonateModal] = useState(false);
+  const lastLockUserId = useRef<number | null>(null);
+
+  const { data, fetchNextPage, isFetching } = trpc.viewer.admin.listPaginated.useInfiniteQuery(
+    { limit: FETCH_LIMIT, searchTerm: debouncedSearchTerm },
+    {
+      getNextPageParam: (lastPage) => lastPage.nextCursor,
+      placeholderData: keepPreviousData,
+      refetchOnWindowFocus: false,
+    }
+  );
+
+  const flatRows = useMemo(() => data?.pages.flatMap((page) => page.rows) ?? [], [data]);
+  const totalRowCount = data?.pages?.[0]?.meta?.totalRowCount ?? 0;
+
+  const deleteUser = trpc.viewer.admin.calid.users.delete.useMutation({
+    onSuccess: async () => {
+      showToast("User has been deleted", "success");
+      utils.viewer.admin.listPaginated.invalidate();
+    },
+    onError: () => {
+      showToast("There has been an error deleting this user.", "error");
+    },
+    onSettled: () => setUserToDelete(null),
+  });
+
+  const sendPasswordReset = trpc.viewer.admin.sendPasswordReset.useMutation({
+    onSuccess: () => showToast("Password reset email has been sent", "success"),
+  });
+
+  const lockUserAccount = trpc.viewer.admin.lockUserAccount.useMutation({
+    onMutate: (input) => {
+      lastLockUserId.current = input.userId;
+    },
+    onSuccess: ({ locked }) => {
+      showToast(locked ? "User was locked" : "User was unlocked", "success");
+      utils.viewer.admin.listPaginated.setInfiniteData(
+        { limit: FETCH_LIMIT, searchTerm: debouncedSearchTerm },
+        (cachedData) => {
+          if (!cachedData) return cachedData;
+          const userId = lastLockUserId.current;
+          if (!userId) return cachedData;
+          return {
+            ...cachedData,
+            pages: cachedData.pages.map((page) => ({
+              ...page,
+              rows: page.rows.map((row) => (row.id === userId ? { ...row, locked } : row)),
+            })),
+          };
+        }
+      );
+      utils.viewer.admin.listPaginated.invalidate();
+    },
+  });
+
+  const handleImpersonate = async (username: string) => {
+    await signIn("impersonation-auth", { redirect: false, username });
+    router.replace("/settings/my-account/profile");
+  };
+
+  const fetchMoreOnBottomReached = useCallback(
+    (containerRef?: HTMLDivElement | null) => {
+      if (!containerRef) return;
+      const { scrollHeight, scrollTop, clientHeight } = containerRef;
+      if (scrollHeight - scrollTop - clientHeight < 300 && !isFetching && flatRows.length < totalRowCount) {
+        fetchNextPage();
+      }
+    },
+    [fetchNextPage, flatRows.length, isFetching, totalRowCount]
+  );
+
+  useEffect(() => {
+    fetchMoreOnBottomReached(tableContainerRef.current);
+  }, [fetchMoreOnBottomReached]);
+
+  return (
+    <div>
+      <TextField
+        placeholder="username or email"
+        label="Search"
+        onChange={(event) => setSearchTerm(event.target.value)}
+      />
+      <div
+        className="border-subtle rounded-md border"
+        ref={tableContainerRef}
+        onScroll={() => fetchMoreOnBottomReached(tableContainerRef.current)}
+        style={{ height: "calc(100vh - 30vh)", overflow: "auto" }}>
+        <Table>
+          <Header>
+            <ColumnTitle widthClassNames="w-auto">User</ColumnTitle>
+            <ColumnTitle>Timezone</ColumnTitle>
+            <ColumnTitle>Role</ColumnTitle>
+            <ColumnTitle widthClassNames="w-auto">
+              <span className="sr-only">Actions</span>
+            </ColumnTitle>
+          </Header>
+
+          <tbody className="divide-subtle divide-y rounded-md">
+            {flatRows.map((user) => (
+              <Row key={user.email}>
+                <Cell widthClassNames="w-auto">
+                  <div className="flex min-h-10">
+                    <Avatar
+                      size="md"
+                      alt={`Avatar of ${user.username || "Nameless"}`}
+                      imageSrc={getUserAvatarUrl({
+                        avatarUrl: user.avatarUrl || undefined,
+                      })}
+                    />
+                    <div className="text-subtle ml-4 font-medium">
+                      <div className="flex gap-3">
+                        <span className="text-default">{user.name}</span>
+                        <span>/{user.username}</span>
+                        {user.profiles?.[0]?.username && (
+                          <span className="flex items-center gap-1">
+                            <Icon name="building" className="text-subtle size-5" />
+                            <span>{user.profiles[0].username}</span>
+                          </span>
+                        )}
+                        {user.locked && <Icon name="lock" />}
+                      </div>
+                      <span className="break-all">{user.email}</span>
+                    </div>
+                  </div>
+                </Cell>
+                <Cell>{user.timeZone}</Cell>
+                <Cell>
+                  <Badge className="capitalize" variant={user.role === "ADMIN" ? "red" : "gray"}>
+                    {user.role.toLowerCase()}
+                  </Badge>
+                </Cell>
+                <Cell widthClassNames="w-auto">
+                  <div className="flex w-full justify-end">
+                    <DropdownActions
+                      actions={[
+                        {
+                          id: "edit",
+                          label: "Edit",
+                          href: `/settings/admin/users/${user.id}/edit`,
+                          icon: "pencil",
+                        },
+                        {
+                          id: "reset-password",
+                          label: "Reset Password",
+                          onClick: () => sendPasswordReset.mutate({ userId: user.id }),
+                          icon: "lock",
+                        },
+                        {
+                          id: "impersonate",
+                          label: "Impersonate",
+                          onClick: () => {
+                            setImpersonateUser(user.username);
+                            setShowImpersonateModal(true);
+                          },
+                          icon: "venetian-mask",
+                        },
+                        {
+                          id: "lock-user",
+                          label: user.locked ? "Unlock User Account" : "Lock User Account",
+                          onClick: () => lockUserAccount.mutate({ userId: user.id, locked: !user.locked }),
+                          icon: "lock",
+                        },
+                        {
+                          id: "delete",
+                          label: "Delete",
+                          color: "destructive",
+                          onClick: () => setUserToDelete(user.id),
+                          icon: "trash",
+                        },
+                      ]}
+                    />
+                  </div>
+                </Cell>
+              </Row>
+            ))}
+          </tbody>
+        </Table>
+      </div>
+
+      <Dialog
+        name="delete-user"
+        open={!!userToDelete}
+        onOpenChange={(open) => {
+          if (!open) setUserToDelete(null);
+        }}>
+        <ConfirmationDialogContent
+          title="Delete User"
+          confirmBtnText="Delete"
+          cancelBtnText="Cancel"
+          variety="danger"
+          onConfirm={() => userToDelete && deleteUser.mutate({ userId: userToDelete })}>
+          <p>Are you sure you want to delete this user?</p>
+        </ConfirmationDialogContent>
+      </Dialog>
+
+      {showImpersonateModal && impersonateUser && (
+        <Dialog open={showImpersonateModal} onOpenChange={() => setShowImpersonateModal(false)}>
+          <DialogContent type="creation" title={t("impersonate")} description={t("impersonation_user_tip")}>
+            <form
+              onSubmit={async (event) => {
+                event.preventDefault();
+                await handleImpersonate(impersonateUser);
+                setShowImpersonateModal(false);
+              }}>
+              <DialogFooter showDivider className="mt-8">
+                <DialogClose color="secondary">{t("cancel")}</DialogClose>
+                <Button color="primary" type="submit">
+                  {t("impersonate")}
+                </Button>
+              </DialogFooter>
+            </form>
+          </DialogContent>
+        </Dialog>
+      )}
+    </div>
+  );
+};

--- a/packages/calid/modules/admin/pages/user-add.tsx
+++ b/packages/calid/modules/admin/pages/user-add.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { usePathname, useRouter } from "next/navigation";
+
+import { trpc } from "@calcom/trpc/react";
+import { showToast } from "@calcom/ui/components/toast";
+
+import { AdminUserForm, type AdminUserFormValues } from "../components/AdminUserForm";
+
+const AdminUserAddPage = () => {
+  const pathname = usePathname();
+  const router = useRouter();
+  const utils = trpc.useUtils();
+
+  const mutation = trpc.viewer.admin.calid.users.add.useMutation({
+    onSuccess: async () => {
+      showToast("User added successfully", "success");
+      await utils.viewer.admin.calid.users.list.invalidate();
+      if (pathname) router.replace(pathname.replace("/add", ""));
+    },
+    onError: () => {
+      showToast("There has been an error adding this user.", "error");
+    },
+  });
+
+  const handleSubmit = (values: AdminUserFormValues) => {
+    mutation.mutate(values);
+  };
+
+  return <AdminUserForm submitLabel="Add user" onSubmit={handleSubmit} />;
+};
+
+export default AdminUserAddPage;

--- a/packages/calid/modules/admin/pages/user-edit.tsx
+++ b/packages/calid/modules/admin/pages/user-edit.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { usePathname, useRouter, useParams } from "next/navigation";
+import { z } from "zod";
+
+import { trpc } from "@calcom/trpc/react";
+import { showToast } from "@calcom/ui/components/toast";
+
+import { AdminUserForm, type AdminUserFormValues } from "../components/AdminUserForm";
+
+const userIdSchema = z.object({ id: z.coerce.number() });
+
+const AdminUserEditPage = () => {
+  const params = useParams();
+  const parsed = userIdSchema.safeParse(params);
+
+  if (!parsed.success) return <div>Invalid input</div>;
+
+  const { data, isLoading } = trpc.viewer.admin.calid.users.get.useQuery({ userId: parsed.data.id });
+
+  if (isLoading) return <div>Loading...</div>;
+  if (!data?.user) return <div>User not found</div>;
+
+  const userForForm: AdminUserFormValues & { id: number } = {
+    id: data.user.id,
+    avatarUrl: data.user.avatarUrl ?? null,
+    name: data.user.name ?? "",
+    username: data.user.username ?? "",
+    email: data.user.email ?? "",
+    bio: data.user.bio ?? "",
+    locale: data.user.locale ?? "en",
+    timeZone: data.user.timeZone ?? "",
+    timeFormat: data.user.timeFormat ?? 12,
+    weekStart: data.user.weekStart ?? "Monday",
+    role: data.user.role ?? "USER",
+    identityProvider: data.user.identityProvider ?? "CAL",
+  };
+
+  return <AdminUserEditView user={userForForm} />;
+};
+
+const AdminUserEditView = ({ user }: { user: AdminUserFormValues & { id: number } }) => {
+  const pathname = usePathname();
+  const router = useRouter();
+  const utils = trpc.useUtils();
+
+  const mutation = trpc.viewer.admin.calid.users.update.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        utils.viewer.admin.calid.users.list.invalidate(),
+        utils.viewer.admin.calid.users.get.invalidate(),
+      ]);
+      showToast("User updated successfully", "success");
+      const base = pathname?.split("/users/")[0];
+      if (base) router.replace(`${base}/users`);
+    },
+    onError: () => {
+      showToast("There has been an error updating this user.", "error");
+    },
+  });
+
+  const handleSubmit = (values: AdminUserFormValues) => {
+    const payload: Partial<AdminUserFormValues & { userId: number }> = {
+      userId: user.id,
+      ...values,
+    };
+
+    if (user.username === values.username) delete payload.username;
+
+    mutation.mutate(payload);
+  };
+
+  return <AdminUserForm defaultValues={user} onSubmit={handleSubmit} />;
+};
+
+export default AdminUserEditPage;

--- a/packages/calid/modules/admin/pages/users-list.tsx
+++ b/packages/calid/modules/admin/pages/users-list.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import NoSSR from "@calcom/lib/components/NoSSR";
+
+import { AdminUsersTable } from "../components/AdminUsersTable";
+
+const AdminUsersListPage = () => {
+  return (
+    <NoSSR>
+      <AdminUsersTable />
+    </NoSSR>
+  );
+};
+
+export default AdminUsersListPage;

--- a/packages/trpc/server/routers/viewer/admin/_router.ts
+++ b/packages/trpc/server/routers/viewer/admin/_router.ts
@@ -1,5 +1,6 @@
 import { authedAdminProcedure } from "../../../procedures/authedProcedure";
 import { router } from "../../../trpc";
+import { calidAdminUsersRouter } from "./calid/usersRouter";
 import { ZCreateSelfHostedLicenseSchema } from "./createSelfHostedLicenseKey.schema";
 import { ZGetAllServicesInputSchema } from "./getAllServices.schema";
 import { ZGetServiceProviderInputSchema } from "./getServiceProvider.schema";
@@ -18,10 +19,6 @@ import {
   workspacePlatformUpdateServiceAccountSchema,
   workspacePlatformToggleEnabledSchema,
 } from "./workspacePlatform/schema";
-
-const NAMESPACE = "admin";
-
-const namespaced = (s: string) => `${NAMESPACE}.${s}`;
 
 export const adminRouter = router({
   listPaginated: authedAdminProcedure.input(ZListMembersSchema).query(async (opts) => {
@@ -103,5 +100,11 @@ export const adminRouter = router({
         const handler = (await import("./updateServiceProvider.handler")).updateServiceProviderHandler;
         return handler(input);
       }),
+  }),
+  calid: router({
+    users: (await import("./calid/usersRouter")).calidAdminUsersRouter,
+  }),
+  calid: router({
+    users: calidAdminUsersRouter,
   }),
 });

--- a/packages/trpc/server/routers/viewer/admin/calid/userSchemas.ts
+++ b/packages/trpc/server/routers/viewer/admin/calid/userSchemas.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+import { _UserModel as User } from "@calcom/prisma/zod";
+
+export const userIdSchema = z.object({ userId: z.coerce.number() });
+
+export const userBodySchema = User.pick({
+  name: true,
+  email: true,
+  username: true,
+  bio: true,
+  timeZone: true,
+  weekStart: true,
+  theme: true,
+  defaultScheduleId: true,
+  locale: true,
+  timeFormat: true,
+  allowDynamicBooking: true,
+  identityProvider: true,
+  role: true,
+  avatarUrl: true,
+});
+
+export const userUpdateSchema = userBodySchema.partial().extend({
+  userId: z.coerce.number(),
+});
+
+export type TUserIdSchema = z.infer<typeof userIdSchema>;
+export type TUserBodySchema = z.infer<typeof userBodySchema>;
+export type TUserUpdateSchema = z.infer<typeof userUpdateSchema>;

--- a/packages/trpc/server/routers/viewer/admin/calid/usersRouter.ts
+++ b/packages/trpc/server/routers/viewer/admin/calid/usersRouter.ts
@@ -1,0 +1,96 @@
+import { WEBAPP_URL, WEBSITE_URL } from "@calcom/lib/constants";
+import prisma from "@calcom/prisma";
+import { CreationSource, RedirectType } from "@calcom/prisma/enums";
+import { authedAdminProcedure } from "@calcom/trpc/server/procedures/authedProcedure";
+import { router } from "@calcom/trpc/server/trpc";
+
+import { TRPCError } from "@trpc/server";
+
+import { userBodySchema, userIdSchema, userUpdateSchema } from "./userSchemas";
+
+const subdomainSuffix = () => {
+  const urlSplit = WEBAPP_URL.replace("https://", "").replace("http://", "").split(".");
+  return urlSplit.length === 3 ? urlSplit.slice(1).join(".") : urlSplit.join(".");
+};
+
+const getOrgFullOrigin = (slug: string | null, options: { protocol: boolean } = { protocol: true }) => {
+  if (!slug) {
+    return options.protocol ? WEBSITE_URL : WEBSITE_URL.replace("https://", "").replace("http://", "");
+  }
+  const origin = `${
+    options.protocol ? `${new URL(WEBSITE_URL).protocol}//` : ""
+  }${slug}.${subdomainSuffix()}`;
+  return origin;
+};
+
+const authedAdminWithRequestedUser = authedAdminProcedure.use(async ({ ctx, next, getRawInput }) => {
+  const parsed = userIdSchema.safeParse(await getRawInput());
+  if (!parsed.success) throw new TRPCError({ code: "BAD_REQUEST", message: "User id is required" });
+  const user = await ctx.prisma.user.findUnique({ where: { id: parsed.data.userId } });
+  if (!user) throw new TRPCError({ code: "NOT_FOUND", message: "User not found" });
+  return next({ ctx: { ...ctx, requestedUser: user } });
+});
+
+export const calidAdminUsersRouter = router({
+  get: authedAdminWithRequestedUser.input(userIdSchema).query(async ({ ctx }) => {
+    return { user: ctx.requestedUser };
+  }),
+  list: authedAdminProcedure.query(async ({ ctx }) => {
+    const users = await ctx.prisma.user.findMany();
+    return users;
+  }),
+  add: authedAdminProcedure.input(userBodySchema).mutation(async ({ ctx, input }) => {
+    const user = await ctx.prisma.user.create({ data: { ...input, creationSource: CreationSource.WEBAPP } });
+    return { user, message: `User with id: ${user.id} added successfully` };
+  }),
+  update: authedAdminProcedure.input(userUpdateSchema).mutation(async ({ ctx, input }) => {
+    const { userId, ...data } = input;
+
+    const user = await ctx.prisma.$transaction(async (tx) => {
+      const updated = await tx.user.update({ where: { id: userId }, data });
+
+      if (updated.movedToProfileId && data.username) {
+        const profile = await tx.profile.update({
+          where: { id: updated.movedToProfileId },
+          data: { username: data.username },
+        });
+
+        if (updated.username && profile.organizationId) {
+          const team = await prisma.team.findUnique({
+            where: { id: profile.organizationId },
+            select: { slug: true },
+          });
+
+          if (!team?.slug) throw new Error("Team has no attached slug.");
+
+          const orgUrlPrefix = getOrgFullOrigin(team.slug);
+          const toUrl = `${orgUrlPrefix}/${data.username}`;
+
+          await prisma.tempOrgRedirect.updateMany({
+            where: { type: RedirectType.User, from: updated.username },
+            data: { toUrl },
+          });
+        }
+
+        return updated;
+      }
+
+      if (data.username) {
+        await tx.profile.updateMany({
+          where: { userId },
+          data: { username: data.username },
+        });
+      }
+
+      return updated;
+    });
+
+    return { user, message: `User with id: ${user.id} updated successfully` };
+  }),
+  delete: authedAdminWithRequestedUser.input(userIdSchema).mutation(async ({ ctx }) => {
+    await ctx.prisma.user.delete({ where: { id: ctx.requestedUser.id } });
+    return { message: `User with id: ${ctx.requestedUser.id} deleted successfully` };
+  }),
+});
+
+export type CalidAdminUsersRouter = typeof calidAdminUsersRouter;

--- a/packages/trpc/server/routers/viewer/admin/listPaginated.handler.ts
+++ b/packages/trpc/server/routers/viewer/admin/listPaginated.handler.ts
@@ -73,6 +73,7 @@ const listPaginatedHandler = async ({ input }: GetOptions) => {
         },
       },
       whitelistWorkflows: true,
+      avatarUrl: true,
     },
   });
 


### PR DESCRIPTION
# Admin Users (Non‑EE) with Custom Backend

## Summary
- Replaced the licensed admin users UI with a new CalID admin module.
- Added a non‑EE admin users backend under `viewer/admin/calid` and wired the UI to it.
- Preserved existing UX (search, infinite scroll, actions) and added avatar support in list.

## Changes
### UI
- New module: `packages/calid/modules/admin` (Users list, add, edit, form, table).
- Routes updated to use new module:
  - `apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/users/page.tsx`
  - `apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/users/[id]/edit/page.tsx`
  - `apps/web/app/(use-page-wrapper)/settings/(admin-layout)/admin/users/add/page.tsx`

### Backend (Non‑EE)
- New router:
  - `packages/trpc/server/routers/viewer/admin/calid/usersRouter.ts`
  - `packages/trpc/server/routers/viewer/admin/calid/userSchemas.ts`
- Wired into:
  - `packages/trpc/server/routers/viewer/admin/_router.ts`

### Other
- Added `avatarUrl` to list response:
  - `packages/trpc/server/routers/viewer/admin/listPaginated.handler.ts`
- Save button dirty‑state fixed (timezone normalization):
  - `packages/calid/modules/admin/components/AdminUserForm.tsx`

## Testing
- Open `/settings/admin/users` (table loads, avatars show).
- Edit user timezone; Save enables on change and disables on revert.
- Lock/unlock, delete, reset password, impersonate actions work.
- Verified DB updates via pgAdmin queries.