### PR TITLE
fix/admin-users-non-ee

### DIFF
--- a/apps/web/app/(use-page-wrapper)/auth/locked/page.tsx
+++ b/apps/web/app/(use-page-wrapper)/auth/locked/page.tsx
@@ -1,0 +1,7 @@
+import LockedAccountView from "~/auth/locked-view";
+
+const Page = async () => {
+  return <LockedAccountView />;
+};
+
+export default Page;

--- a/apps/web/modules/auth/locked-view.tsx
+++ b/apps/web/modules/auth/locked-view.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { Button } from "@calid/features/ui/components/button";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@calid/features/ui/components/card";
+import { Icon } from "@calid/features/ui/components/icon";
+import { Logo } from "@calid/features/ui/components/logo";
+
+const SUPPORT_EMAIL = "support@onehash.ai";
+
+export default function LockedAccountView() {
+  return (
+    <div className="dark:bg-default flex min-h-screen flex-col items-center justify-center bg-[#F0F5FF] p-4">
+      <Card className="bg-default dark:border-gray-550 w-full max-w-[600px] overflow-hidden rounded-3xl border shadow-xl dark:shadow-none">
+        <CardHeader className="items-center gap-3">
+          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-100 text-red-600">
+            <Icon name="lock" className="h-6 w-6" />
+          </div>
+          <CardTitle className="text-default text-xl font-semibold">Account locked</CardTitle>
+          <CardDescription className="text-subtle text-center">
+            Your account has been locked. Please contact support to continue.
+          </CardDescription>
+        </CardHeader>
+        <CardContent />
+        <CardFooter className="justify-center pb-6">
+          <Button color="primary" asChild>
+            <a href={`mailto:${SUPPORT_EMAIL}`}>Contact Support</a>
+          </Button>
+        </CardFooter>
+      </Card>
+      <div className="mt-8">
+        <Logo small icon />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/modules/auth/login-view.tsx
+++ b/apps/web/modules/auth/login-view.tsx
@@ -17,7 +17,7 @@ import { WEBAPP_URL } from "@calcom/lib/constants";
 import { emailRegex } from "@calcom/lib/emailSchema";
 import { getSafeRedirectUrl } from "@calcom/lib/getSafeRedirectUrl";
 import { useCompatSearchParams } from "@calcom/lib/hooks/useCompatSearchParams";
-import { LastUsed, useLastUsed } from "@calcom/lib/hooks/useLastUsed";
+import { useLastUsed } from "@calcom/lib/hooks/useLastUsed";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { useTelemetry } from "@calcom/lib/hooks/useTelemetry";
 import { collectPageParameters, telemetryEventTypes } from "@calcom/lib/telemetry";
@@ -155,6 +155,8 @@ export default function Login({
     else if (!res.error) {
       setLastUsed("credentials");
       router.push(callbackUrl);
+    } else if (res.error === ErrorCode.UserAccountLocked || res.url?.includes("/auth/locked")) {
+      router.push("/auth/locked");
     } else if (res.error === ErrorCode.SecondFactorRequired) setTwoFactorRequired(true);
     else if (res.error === ErrorCode.IncorrectBackupCode) setErrorMessage(t("incorrect_backup_code"));
     else if (res.error === ErrorCode.MissingBackupCodes) setErrorMessage(t("missing_backup_codes"));
@@ -279,7 +281,7 @@ export default function Login({
                               <span className="hidden sm:inline">{t("signin_with_google")}</span>
                             </Button>
                             {lastUsed === "google" && (
-                              <span className="absolute -top-3 right-2 z-10 rounded-full border border-gray-200 bg-default px-2.5 py-1 text-xs font-semibold text-default">
+                              <span className="bg-default text-default absolute -top-3 right-2 z-10 rounded-full border border-gray-200 px-2.5 py-1 text-xs font-semibold">
                                 ⭐ Last Used
                               </span>
                             )}
@@ -367,7 +369,7 @@ export default function Login({
                         <span>{twoFactorRequired ? t("submit") : t("sign_in")}</span>
                       </Button>
                       {lastUsed === "credentials" && (
-                        <span className="bg-default absolute right-2 -top-3 z-10 rounded-full border border-gray-200 px-2.5 py-1 text-xs font-semibold text-default">
+                        <span className="bg-default text-default absolute -top-3 right-2 z-10 rounded-full border border-gray-200 px-2.5 py-1 text-xs font-semibold">
                           ⭐ Last Used
                         </span>
                       )}

--- a/apps/web/modules/users/views/user-not-found-view.tsx
+++ b/apps/web/modules/users/views/user-not-found-view.tsx
@@ -269,6 +269,13 @@ function FloatingFeatureBubbles() {
 
 export function UserNotFoundView({ slug }: UserNotFoundViewProps) {
   const { t } = useLocale();
+  const [host, setHost] = useState("");
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      setHost(window.location.host);
+    }
+  }, []);
 
   const features = [
     {
@@ -306,7 +313,8 @@ export function UserNotFoundView({ slug }: UserNotFoundViewProps) {
             </div>
 
             <h1 className="text-default mb-4 text-4xl font-bold leading-tight md:text-5xl lg:text-6xl">
-              {t("claim")} <span className="text-active">cal.id/{slug}</span> {t("before_someone_else_does")}
+              {t("claim")} <span className="text-active">{host ? `${host}/${slug}` : slug}</span>{" "}
+              {t("before_someone_else_does")}
             </h1>
 
             <p className="text-default mb-8 text-lg md:text-xl">{t("claim_username_description")}</p>

--- a/packages/calid/modules/admin/components/AdminUserForm.tsx
+++ b/packages/calid/modules/admin/components/AdminUserForm.tsx
@@ -1,5 +1,10 @@
 "use client";
 
+import { Avatar } from "@calid/features/ui/components/avatar";
+import { Button } from "@calid/features/ui/components/button";
+import { Form } from "@calid/features/ui/components/form";
+import { EmailField, TextField } from "@calid/features/ui/components/input/input";
+import { Label } from "@calid/features/ui/components/label";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { Controller, useForm, useWatch } from "react-hook-form";
 
@@ -8,9 +13,7 @@ import { getUserAvatarUrl } from "@calcom/lib/getAvatarUrl";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { defaultLocaleOption, localeOptions } from "@calcom/lib/i18n";
 import { nameOfDay } from "@calcom/lib/weekday";
-import { Avatar } from "@calcom/ui/components/avatar";
-import { Button } from "@calcom/ui/components/button";
-import { EmailField, Form, Label, Select, TextField } from "@calcom/ui/components/form";
+import { Select } from "@calcom/ui/components/form";
 import { ImageUploader } from "@calcom/ui/components/image-uploader";
 
 export type AdminUserFormValues = {
@@ -28,9 +31,8 @@ export type AdminUserFormValues = {
 };
 
 const identityProviderOptions = [
-  { value: "CAL", label: "CAL" },
   { value: "GOOGLE", label: "GOOGLE" },
-  { value: "SAML", label: "SAML" },
+  { value: "CAL", label: "CAL" },
 ];
 
 const roleOptions = [
@@ -135,7 +137,7 @@ export const AdminUserForm = ({
   }, [normalizeValues, watchedValues]);
 
   return (
-    <Form form={form} className="space-y-4" handleSubmit={onSubmit}>
+    <Form form={form} className="space-y-4" onSubmit={onSubmit}>
       <div className="flex items-center">
         <Controller
           control={form.control}

--- a/packages/calid/modules/admin/components/AdminUsersTable.tsx
+++ b/packages/calid/modules/admin/components/AdminUsersTable.tsx
@@ -1,5 +1,19 @@
 "use client";
 
+import { Avatar } from "@calid/features/ui/components/avatar";
+import { Button } from "@calid/features/ui/components/button";
+import {
+  Dialog as CalidDialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@calid/features/ui/components/dialog";
+import { Icon } from "@calid/features/ui/components/icon";
+import { TextField } from "@calid/features/ui/components/input/input";
+import { triggerToast } from "@calid/features/ui/components/toast";
 import { keepPreviousData } from "@tanstack/react-query";
 import { signIn } from "next-auth/react";
 import { useRouter } from "next/navigation";
@@ -9,20 +23,7 @@ import { getUserAvatarUrl } from "@calcom/lib/getAvatarUrl";
 import { useDebounce } from "@calcom/lib/hooks/useDebounce";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
-import { Avatar } from "@calcom/ui/components/avatar";
-import { Badge } from "@calcom/ui/components/badge";
-import { Button } from "@calcom/ui/components/button";
-import {
-  ConfirmationDialogContent,
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogFooter,
-} from "@calcom/ui/components/dialog";
-import { TextField } from "@calcom/ui/components/form";
-import { Icon } from "@calcom/ui/components/icon";
 import { DropdownActions, Table } from "@calcom/ui/components/table";
-import { showToast } from "@calcom/ui/components/toast";
 
 const { Cell, ColumnTitle, Header, Row } = Table;
 
@@ -56,17 +57,17 @@ export const AdminUsersTable = () => {
 
   const deleteUser = trpc.viewer.admin.calid.users.delete.useMutation({
     onSuccess: async () => {
-      showToast("User has been deleted", "success");
+      triggerToast("User has been deleted", "success");
       utils.viewer.admin.listPaginated.invalidate();
     },
     onError: () => {
-      showToast("There has been an error deleting this user.", "error");
+      triggerToast("There has been an error deleting this user.", "error");
     },
     onSettled: () => setUserToDelete(null),
   });
 
   const sendPasswordReset = trpc.viewer.admin.sendPasswordReset.useMutation({
-    onSuccess: () => showToast("Password reset email has been sent", "success"),
+    onSuccess: () => triggerToast("Password reset email has been sent", "success"),
   });
 
   const lockUserAccount = trpc.viewer.admin.lockUserAccount.useMutation({
@@ -74,7 +75,7 @@ export const AdminUsersTable = () => {
       lastLockUserId.current = input.userId;
     },
     onSuccess: ({ locked }) => {
-      showToast(locked ? "User was locked" : "User was unlocked", "success");
+      triggerToast(locked ? "User was locked" : "User was unlocked", "success");
       utils.viewer.admin.listPaginated.setInfiniteData(
         { limit: FETCH_LIMIT, searchTerm: debouncedSearchTerm },
         (cachedData) => {
@@ -116,21 +117,51 @@ export const AdminUsersTable = () => {
 
   return (
     <div>
+      <style jsx global>{`
+        .admin-users-table thead th {
+          position: sticky;
+          top: 0;
+          z-index: 1;
+          background: var(--color-bg-default, #fff);
+        }
+        .admin-users-table > div {
+          overflow: visible !important;
+        }
+        .admin-users-table thead tr {
+          position: sticky;
+          top: 0;
+          z-index: 1;
+          background: var(--color-bg-default, #fff);
+        }
+      `}</style>
       <TextField
         placeholder="username or email"
         label="Search"
+        className="mb-3"
         onChange={(event) => setSearchTerm(event.target.value)}
       />
       <div
-        className="border-subtle rounded-md border"
+        className="admin-users-table border-subtle rounded-md border"
         ref={tableContainerRef}
         onScroll={() => fetchMoreOnBottomReached(tableContainerRef.current)}
-        style={{ height: "calc(100vh - 30vh)", overflow: "auto" }}>
+        style={{ height: "calc(100vh - 24vh)", overflow: "auto" }}>
         <Table>
           <Header>
-            <ColumnTitle widthClassNames="w-auto">User</ColumnTitle>
-            <ColumnTitle>Timezone</ColumnTitle>
-            <ColumnTitle>Role</ColumnTitle>
+            <ColumnTitle widthClassNames="w-auto">
+              <span className="bg-subtle/60 text-muted inline-flex rounded px-2 py-1 text-[11px] font-semibold uppercase">
+                User
+              </span>
+            </ColumnTitle>
+            <ColumnTitle>
+              <span className="bg-subtle/60 text-muted inline-flex rounded px-2 py-1 text-[11px] font-semibold uppercase">
+                Timezone
+              </span>
+            </ColumnTitle>
+            <ColumnTitle>
+              <span className="bg-subtle/60 text-muted inline-flex rounded px-2 py-1 text-[11px] font-semibold uppercase">
+                Role
+              </span>
+            </ColumnTitle>
             <ColumnTitle widthClassNames="w-auto">
               <span className="sr-only">Actions</span>
             </ColumnTitle>
@@ -166,9 +197,12 @@ export const AdminUsersTable = () => {
                 </Cell>
                 <Cell>{user.timeZone}</Cell>
                 <Cell>
-                  <Badge className="capitalize" variant={user.role === "ADMIN" ? "red" : "gray"}>
-                    {user.role.toLowerCase()}
-                  </Badge>
+                  <span
+                    className={
+                      user.role === "ADMIN" ? "font-semibold text-red-600" : "text-default font-medium"
+                    }>
+                    {user.role === "ADMIN" ? "Admin" : "User"}
+                  </span>
                 </Cell>
                 <Cell widthClassNames="w-auto">
                   <div className="flex w-full justify-end">
@@ -218,32 +252,38 @@ export const AdminUsersTable = () => {
         </Table>
       </div>
 
-      <Dialog
-        name="delete-user"
-        open={!!userToDelete}
-        onOpenChange={(open) => {
-          if (!open) setUserToDelete(null);
-        }}>
-        <ConfirmationDialogContent
-          title="Delete User"
-          confirmBtnText="Delete"
-          cancelBtnText="Cancel"
-          variety="danger"
-          onConfirm={() => userToDelete && deleteUser.mutate({ userId: userToDelete })}>
-          <p>Are you sure you want to delete this user?</p>
-        </ConfirmationDialogContent>
-      </Dialog>
+      <CalidDialog open={!!userToDelete} onOpenChange={(open) => !open && setUserToDelete(null)}>
+        <DialogContent size="md" showCloseButton>
+          <DialogHeader showIcon variant="warning">
+            <DialogTitle>Delete User</DialogTitle>
+            <DialogDescription>Are you sure you want to delete this user?</DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="mt-8">
+            <DialogClose color="secondary">{t("cancel")}</DialogClose>
+            <Button
+              color="primary"
+              type="button"
+              onClick={() => userToDelete && deleteUser.mutate({ userId: userToDelete })}>
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </CalidDialog>
 
       {showImpersonateModal && impersonateUser && (
-        <Dialog open={showImpersonateModal} onOpenChange={() => setShowImpersonateModal(false)}>
-          <DialogContent type="creation" title={t("impersonate")} description={t("impersonation_user_tip")}>
+        <CalidDialog open={showImpersonateModal} onOpenChange={setShowImpersonateModal}>
+          <DialogContent size="md" showCloseButton>
+            <DialogHeader>
+              <DialogTitle>{t("impersonate")}</DialogTitle>
+              <DialogDescription>{t("impersonation_user_tip")}</DialogDescription>
+            </DialogHeader>
             <form
               onSubmit={async (event) => {
                 event.preventDefault();
                 await handleImpersonate(impersonateUser);
                 setShowImpersonateModal(false);
               }}>
-              <DialogFooter showDivider className="mt-8">
+              <DialogFooter className="mt-8">
                 <DialogClose color="secondary">{t("cancel")}</DialogClose>
                 <Button color="primary" type="submit">
                   {t("impersonate")}
@@ -251,7 +291,7 @@ export const AdminUsersTable = () => {
               </DialogFooter>
             </form>
           </DialogContent>
-        </Dialog>
+        </CalidDialog>
       )}
     </div>
   );

--- a/packages/calid/modules/admin/pages/user-add.tsx
+++ b/packages/calid/modules/admin/pages/user-add.tsx
@@ -1,9 +1,9 @@
 "use client";
 
+import { triggerToast } from "@calid/features/ui/components/toast";
 import { usePathname, useRouter } from "next/navigation";
 
 import { trpc } from "@calcom/trpc/react";
-import { showToast } from "@calcom/ui/components/toast";
 
 import { AdminUserForm, type AdminUserFormValues } from "../components/AdminUserForm";
 
@@ -14,12 +14,12 @@ const AdminUserAddPage = () => {
 
   const mutation = trpc.viewer.admin.calid.users.add.useMutation({
     onSuccess: async () => {
-      showToast("User added successfully", "success");
+      triggerToast("User added successfully", "success");
       await utils.viewer.admin.calid.users.list.invalidate();
       if (pathname) router.replace(pathname.replace("/add", ""));
     },
     onError: () => {
-      showToast("There has been an error adding this user.", "error");
+      triggerToast("There has been an error adding this user.", "error");
     },
   });
 

--- a/packages/calid/modules/admin/pages/user-edit.tsx
+++ b/packages/calid/modules/admin/pages/user-edit.tsx
@@ -1,10 +1,10 @@
 "use client";
 
+import { triggerToast } from "@calid/features/ui/components/toast";
 import { usePathname, useRouter, useParams } from "next/navigation";
 import { z } from "zod";
 
 import { trpc } from "@calcom/trpc/react";
-import { showToast } from "@calcom/ui/components/toast";
 
 import { AdminUserForm, type AdminUserFormValues } from "../components/AdminUserForm";
 
@@ -50,12 +50,12 @@ const AdminUserEditView = ({ user }: { user: AdminUserFormValues & { id: number 
         utils.viewer.admin.calid.users.list.invalidate(),
         utils.viewer.admin.calid.users.get.invalidate(),
       ]);
-      showToast("User updated successfully", "success");
+      triggerToast("User updated successfully", "success");
       const base = pathname?.split("/users/")[0];
       if (base) router.replace(`${base}/users`);
     },
     onError: () => {
-      showToast("There has been an error updating this user.", "error");
+      triggerToast("There has been an error updating this user.", "error");
     },
   });
 

--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -117,6 +117,17 @@ const providers: Provider[] = [
       }
 
       const userRepo = new UserRepository(prisma);
+      const lockedCheck = await prisma.user.findFirst({
+        where: {
+          email: credentials.email.toLowerCase(),
+          OR: [{ locked: false }, { locked: true }],
+        },
+        select: { locked: true },
+      });
+      if (lockedCheck?.locked) {
+        throw new Error(ErrorCode.UserAccountLocked);
+      }
+
       const user = await userRepo.findByEmailAndIncludeProfilesAndPassword({
         email: credentials.email,
       });
@@ -833,6 +844,10 @@ export const getOptions = ({
           },
         });
 
+        if (existingUser?.locked) {
+          return "/auth/locked";
+        }
+
         /* --- START FIX LEGACY ISSUE WHERE 'identityProviderId' was accidentally set to userId --- */
         if (!existingUser) {
           existingUser = await prisma.user.findFirst({
@@ -860,6 +875,9 @@ export const getOptions = ({
           }
         }
         /* --- END FIXES LEGACY ISSUE WHERE 'identityProviderId' was accidentally set to userId --- */
+        if (existingUser?.locked) {
+          return "/auth/locked";
+        }
         if (existingUser) {
           // In this case there's an existing user and their email address
           // hasn't changed since they last logged in.

--- a/packages/lib/server/checkRegularUsername.ts
+++ b/packages/lib/server/checkRegularUsername.ts
@@ -33,6 +33,7 @@ export async function checkRegularUsername(_username: string, currentOrgDomain?:
       where: {
         username,
         organizationId: null,
+        OR: [{ locked: false }, { locked: true }],
       },
       select: {
         id: true,


### PR DESCRIPTION
# Admin Users + Locked Account UX Updates (Brief)

## Summary
- Styled role text to show **Admin** in red.
- Added locked-account UX (new `/auth/locked` page + redirect for locked users).
- Improved admin users table UI (spacing, sticky header, header pills, taller scroll area).
- Switched more UI pieces to CalID components.