### PR TITLE
Admin users filters/sort + lastActiveAt tracking

### DIFF
--- a/apps/web/pages/api/auth/[...nextauth].ts
+++ b/apps/web/pages/api/auth/[...nextauth].ts
@@ -12,6 +12,7 @@ const handler = (req: NextApiRequest, res: NextApiResponse) =>
       cookies: {
         utm_params: req.cookies.utm_params,
         dub_id: req.cookies.dub_id || req.cookies.dclid,
+        last_active_throttle: req.cookies.last_active_throttle,
       },
       res,
     })

--- a/packages/calid/modules/admin/components/AdminUsersTable.tsx
+++ b/packages/calid/modules/admin/components/AdminUsersTable.tsx
@@ -17,48 +17,98 @@ import { triggerToast } from "@calid/features/ui/components/toast";
 import { keepPreviousData } from "@tanstack/react-query";
 import { signIn } from "next-auth/react";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { getUserAvatarUrl } from "@calcom/lib/getAvatarUrl";
 import { useDebounce } from "@calcom/lib/hooks/useDebounce";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
+import { Pagination } from "@calcom/ui/components/pagination";
 import { DropdownActions, Table } from "@calcom/ui/components/table";
 
 const { Cell, ColumnTitle, Header, Row } = Table;
 
-const FETCH_LIMIT = 25;
+const DEFAULT_PAGE_SIZE = 25;
+const ROLE_FILTER_OPTIONS = [
+  { value: "ALL", label: "All roles" },
+  { value: "USER", label: "User" },
+  { value: "ADMIN", label: "Admin" },
+];
+const STATUS_FILTER_OPTIONS = [
+  { value: "ALL", label: "All statuses" },
+  { value: "UNLOCKED", label: "Unlocked" },
+  { value: "LOCKED", label: "Locked" },
+];
 
 export const AdminUsersTable = () => {
   const { t } = useLocale();
   const router = useRouter();
-  const tableContainerRef = useRef<HTMLDivElement>(null);
   const utils = trpc.useUtils();
 
   const [searchTerm, setSearchTerm] = useState("");
   const debouncedSearchTerm = useDebounce(searchTerm, 500);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+  const [pageIndex, setPageIndex] = useState(0);
+  const [roleFilter, setRoleFilter] = useState<"ADMIN" | "USER" | null>(null);
+  const [statusFilter, setStatusFilter] = useState<"LOCKED" | "UNLOCKED" | null>(null);
+  const [sortBy, setSortBy] = useState<"name" | "email" | "createdDate" | "role" | null>(null);
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("asc");
+  const [userSortOpen, setUserSortOpen] = useState(false);
+  const [roleFilterOpen, setRoleFilterOpen] = useState(false);
+  const [statusFilterOpen, setStatusFilterOpen] = useState(false);
+  const userSortRef = useRef<HTMLDivElement | null>(null);
+  const roleFilterRef = useRef<HTMLDivElement | null>(null);
+  const statusFilterRef = useRef<HTMLDivElement | null>(null);
 
   const [userToDelete, setUserToDelete] = useState<number | null>(null);
   const [impersonateUser, setImpersonateUser] = useState<string | null>(null);
   const [showImpersonateModal, setShowImpersonateModal] = useState(false);
   const lastLockUserId = useRef<number | null>(null);
 
-  const { data, fetchNextPage, isFetching } = trpc.viewer.admin.listPaginated.useInfiniteQuery(
-    { limit: FETCH_LIMIT, searchTerm: debouncedSearchTerm },
-    {
-      getNextPageParam: (lastPage) => lastPage.nextCursor,
-      placeholderData: keepPreviousData,
-      refetchOnWindowFocus: false,
-    }
+  const queryInput = useMemo(
+    () => ({
+      limit: pageSize,
+      offset: pageIndex * pageSize,
+      searchTerm: debouncedSearchTerm || null,
+      role: roleFilter,
+      locked: statusFilter === null ? null : statusFilter === "LOCKED",
+      sortBy,
+      sortDir: sortBy ? sortDir : null,
+    }),
+    [debouncedSearchTerm, pageIndex, pageSize, roleFilter, sortBy, sortDir, statusFilter]
   );
 
-  const flatRows = useMemo(() => data?.pages.flatMap((page) => page.rows) ?? [], [data]);
-  const totalRowCount = data?.pages?.[0]?.meta?.totalRowCount ?? 0;
+  const { data } = trpc.viewer.admin.calid.users.listPaginated.useQuery(queryInput, {
+    placeholderData: keepPreviousData,
+    refetchOnWindowFocus: false,
+  });
+
+  const rows = useMemo(() => data?.rows ?? [], [data]);
+  const totalRowCount = data?.meta?.totalRowCount ?? 0;
+
+  useEffect(() => {
+    setPageIndex(0);
+  }, [debouncedSearchTerm, roleFilter, statusFilter, sortBy, sortDir]);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (userSortRef.current && userSortRef.current.contains(target)) return;
+      if (roleFilterRef.current && roleFilterRef.current.contains(target)) return;
+      if (statusFilterRef.current && statusFilterRef.current.contains(target)) return;
+      setUserSortOpen(false);
+      setRoleFilterOpen(false);
+      setStatusFilterOpen(false);
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
 
   const deleteUser = trpc.viewer.admin.calid.users.delete.useMutation({
     onSuccess: async () => {
       triggerToast("User has been deleted", "success");
-      utils.viewer.admin.listPaginated.invalidate();
+      utils.viewer.admin.calid.users.listPaginated.invalidate();
     },
     onError: () => {
       triggerToast("There has been an error deleting this user.", "error");
@@ -76,22 +126,16 @@ export const AdminUsersTable = () => {
     },
     onSuccess: ({ locked }) => {
       triggerToast(locked ? "User was locked" : "User was unlocked", "success");
-      utils.viewer.admin.listPaginated.setInfiniteData(
-        { limit: FETCH_LIMIT, searchTerm: debouncedSearchTerm },
-        (cachedData) => {
-          if (!cachedData) return cachedData;
-          const userId = lastLockUserId.current;
-          if (!userId) return cachedData;
-          return {
-            ...cachedData,
-            pages: cachedData.pages.map((page) => ({
-              ...page,
-              rows: page.rows.map((row) => (row.id === userId ? { ...row, locked } : row)),
-            })),
-          };
-        }
-      );
-      utils.viewer.admin.listPaginated.invalidate();
+      utils.viewer.admin.calid.users.listPaginated.setData(queryInput, (cachedData) => {
+        if (!cachedData) return cachedData;
+        const userId = lastLockUserId.current;
+        if (!userId) return cachedData;
+        return {
+          ...cachedData,
+          rows: cachedData.rows.map((row) => (row.id === userId ? { ...row, locked } : row)),
+        };
+      });
+      utils.viewer.admin.calid.users.listPaginated.invalidate();
     },
   });
 
@@ -100,20 +144,41 @@ export const AdminUsersTable = () => {
     router.replace("/settings/my-account/profile");
   };
 
-  const fetchMoreOnBottomReached = useCallback(
-    (containerRef?: HTMLDivElement | null) => {
-      if (!containerRef) return;
-      const { scrollHeight, scrollTop, clientHeight } = containerRef;
-      if (scrollHeight - scrollTop - clientHeight < 300 && !isFetching && flatRows.length < totalRowCount) {
-        fetchNextPage();
-      }
-    },
-    [fetchNextPage, flatRows.length, isFetching, totalRowCount]
-  );
+  const toggleSort = (column: "name" | "email" | "createdDate" | "role") => {
+    if (sortBy === column) {
+      setSortDir((prev) => (prev === "asc" ? "desc" : "asc"));
+      return;
+    }
+    setSortBy(column);
+    setSortDir("asc");
+  };
 
-  useEffect(() => {
-    fetchMoreOnBottomReached(tableContainerRef.current);
-  }, [fetchMoreOnBottomReached]);
+  const getSortIcon = (column: "name" | "email" | "createdDate" | "role") => {
+    if (sortBy !== column) return "chevrons-up-down";
+    return sortDir === "asc" ? "chevron-up" : "chevron-down";
+  };
+
+  const formatDateTime = (value?: Date | string | null) => {
+    if (!value) return "—";
+    const date = typeof value === "string" ? new Date(value) : value;
+    if (Number.isNaN(date.getTime())) return "—";
+    const parts = new Intl.DateTimeFormat("en-GB", {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+      hour12: true,
+    }).formatToParts(date);
+    const get = (type: string) => parts.find((part) => part.type === type)?.value ?? "";
+    const day = get("day");
+    const month = get("month");
+    const year = get("year");
+    const hour = get("hour");
+    const minute = get("minute");
+    const dayPeriod = get("dayPeriod").toUpperCase();
+    return `${day} ${month} ${year} ${hour}:${minute} ${dayPeriod}`.trim();
+  };
 
   return (
     <div>
@@ -140,17 +205,77 @@ export const AdminUsersTable = () => {
         className="mb-3"
         onChange={(event) => setSearchTerm(event.target.value)}
       />
-      <div
-        className="admin-users-table border-subtle rounded-md border"
-        ref={tableContainerRef}
-        onScroll={() => fetchMoreOnBottomReached(tableContainerRef.current)}
-        style={{ height: "calc(100vh - 24vh)", overflow: "auto" }}>
+      <div className="admin-users-table border-subtle rounded-md border" style={{ overflow: "visible" }}>
         <Table>
           <Header>
             <ColumnTitle widthClassNames="w-auto">
-              <span className="bg-subtle/60 text-muted inline-flex rounded px-2 py-1 text-[11px] font-semibold uppercase">
-                User
-              </span>
+              <div className="flex flex-col gap-2">
+                <div className="flex items-center gap-2">
+                  <span className="bg-subtle/60 text-muted inline-flex w-fit rounded px-2 py-1 text-[11px] font-semibold uppercase">
+                    User
+                  </span>
+                  <div className="relative" ref={userSortRef}>
+                    <button
+                      type="button"
+                      className={`inline-flex h-6 w-6 items-center justify-center rounded border text-[11px] ${
+                        sortBy === "name" || sortBy === "email"
+                          ? "text-default border-subtle"
+                          : "text-subtle hover:text-default border-transparent"
+                      }`}
+                      onClick={() => {
+                        setUserSortOpen((prev) => !prev);
+                        setRoleFilterOpen(false);
+                        setStatusFilterOpen(false);
+                      }}>
+                      <Icon name="chevron-down" className="h-3 w-3" />
+                    </button>
+                    {userSortOpen && (
+                      <div className="bg-default border-subtle absolute left-0 z-20 mt-2 w-44 rounded-md border p-1 shadow-md">
+                        <button
+                          type="button"
+                          className="text-default hover:bg-subtle w-full rounded px-2 py-1 text-left text-xs"
+                          onClick={() => {
+                            setSortBy("name");
+                            setSortDir("asc");
+                            setUserSortOpen(false);
+                          }}>
+                          Name - A to Z
+                        </button>
+                        <button
+                          type="button"
+                          className="text-default hover:bg-subtle w-full rounded px-2 py-1 text-left text-xs"
+                          onClick={() => {
+                            setSortBy("email");
+                            setSortDir("asc");
+                            setUserSortOpen(false);
+                          }}>
+                          Email - A to Z
+                        </button>
+                        <button
+                          type="button"
+                          className="text-default hover:bg-subtle w-full rounded px-2 py-1 text-left text-xs"
+                          onClick={() => {
+                            setSortBy("name");
+                            setSortDir("desc");
+                            setUserSortOpen(false);
+                          }}>
+                          Name - Z to A
+                        </button>
+                        <button
+                          type="button"
+                          className="text-default hover:bg-subtle w-full rounded px-2 py-1 text-left text-xs"
+                          onClick={() => {
+                            setSortBy("email");
+                            setSortDir("desc");
+                            setUserSortOpen(false);
+                          }}>
+                          Email - Z to A
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
             </ColumnTitle>
             <ColumnTitle>
               <span className="bg-subtle/60 text-muted inline-flex rounded px-2 py-1 text-[11px] font-semibold uppercase">
@@ -158,8 +283,97 @@ export const AdminUsersTable = () => {
               </span>
             </ColumnTitle>
             <ColumnTitle>
+              <div className="flex items-center gap-2">
+                <span className="bg-subtle/60 text-muted inline-flex w-fit rounded px-2 py-1 text-[11px] font-semibold uppercase">
+                  Role
+                </span>
+                <div className="relative" ref={roleFilterRef}>
+                  <button
+                    type="button"
+                    className={`inline-flex h-6 w-6 items-center justify-center rounded border text-[11px] ${
+                      roleFilter
+                        ? "text-default border-subtle"
+                        : "text-subtle hover:text-default border-transparent"
+                    }`}
+                    onClick={() => {
+                      setRoleFilterOpen((prev) => !prev);
+                      setUserSortOpen(false);
+                      setStatusFilterOpen(false);
+                    }}>
+                    <Icon name="chevron-down" className="h-3 w-3" />
+                  </button>
+                  {roleFilterOpen && (
+                    <div className="bg-default border-subtle absolute left-0 z-20 mt-2 w-36 rounded-md border p-1 shadow-md">
+                      {ROLE_FILTER_OPTIONS.map((option) => (
+                        <button
+                          key={option.value}
+                          type="button"
+                          className="text-default hover:bg-subtle w-full rounded px-2 py-1 text-left text-xs"
+                          onClick={() => {
+                            const value = option.value ?? "ALL";
+                            setRoleFilter(value === "ALL" ? null : (value as "ADMIN" | "USER"));
+                            setRoleFilterOpen(false);
+                          }}>
+                          {option.label}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </ColumnTitle>
+            <ColumnTitle>
+              <div className="flex items-center gap-2">
+                <span className="bg-subtle/60 text-muted inline-flex w-fit rounded px-2 py-1 text-[11px] font-semibold uppercase">
+                  Status
+                </span>
+                <div className="relative" ref={statusFilterRef}>
+                  <button
+                    type="button"
+                    className={`inline-flex h-6 w-6 items-center justify-center rounded border text-[11px] ${
+                      statusFilter
+                        ? "text-default border-subtle"
+                        : "text-subtle hover:text-default border-transparent"
+                    }`}
+                    onClick={() => {
+                      setStatusFilterOpen((prev) => !prev);
+                      setUserSortOpen(false);
+                      setRoleFilterOpen(false);
+                    }}>
+                    <Icon name="chevron-down" className="h-3 w-3" />
+                  </button>
+                  {statusFilterOpen && (
+                    <div className="bg-default border-subtle absolute left-0 z-20 mt-2 w-40 rounded-md border p-1 shadow-md">
+                      {STATUS_FILTER_OPTIONS.map((option) => (
+                        <button
+                          key={option.value}
+                          type="button"
+                          className="text-default hover:bg-subtle w-full rounded px-2 py-1 text-left text-xs"
+                          onClick={() => {
+                            const value = option.value ?? "ALL";
+                            setStatusFilter(value === "ALL" ? null : (value as "LOCKED" | "UNLOCKED"));
+                            setStatusFilterOpen(false);
+                          }}>
+                          {option.label}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </ColumnTitle>
+            <ColumnTitle>
+              <button
+                type="button"
+                className="bg-subtle/60 text-muted inline-flex items-center gap-1 rounded px-2 py-1 text-[11px] font-semibold uppercase"
+                onClick={() => toggleSort("createdDate")}>
+                Created
+                <Icon name={getSortIcon("createdDate")} className="h-3 w-3" />
+              </button>
+            </ColumnTitle>
+            <ColumnTitle>
               <span className="bg-subtle/60 text-muted inline-flex rounded px-2 py-1 text-[11px] font-semibold uppercase">
-                Role
+                Last active
               </span>
             </ColumnTitle>
             <ColumnTitle widthClassNames="w-auto">
@@ -168,7 +382,7 @@ export const AdminUsersTable = () => {
           </Header>
 
           <tbody className="divide-subtle divide-y rounded-md">
-            {flatRows.map((user) => (
+            {rows.map((user) => (
               <Row key={user.email}>
                 <Cell widthClassNames="w-auto">
                   <div className="flex min-h-10">
@@ -204,6 +418,18 @@ export const AdminUsersTable = () => {
                     {user.role === "ADMIN" ? "Admin" : "User"}
                   </span>
                 </Cell>
+                <Cell>
+                  <span
+                    className={
+                      user.locked
+                        ? "text-default rounded bg-red-100 px-2 py-1 text-xs font-semibold"
+                        : "text-default rounded bg-green-100 px-2 py-1 text-xs font-semibold"
+                    }>
+                    {user.locked ? "Locked" : "Unlocked"}
+                  </span>
+                </Cell>
+                <Cell>{formatDateTime(user.createdDate)}</Cell>
+                <Cell>{formatDateTime(user.lastActiveAt)}</Cell>
                 <Cell widthClassNames="w-auto">
                   <div className="flex w-full justify-end">
                     <DropdownActions
@@ -250,6 +476,18 @@ export const AdminUsersTable = () => {
             ))}
           </tbody>
         </Table>
+      </div>
+      <div className="mt-4">
+        <Pagination
+          currentPage={pageIndex + 1}
+          pageSize={pageSize}
+          totalItems={totalRowCount}
+          onPageChange={(page) => setPageIndex(page - 1)}
+          onPageSizeChange={(size) => {
+            setPageSize(size);
+            setPageIndex(0);
+          }}
+        />
       </div>
 
       <CalidDialog open={!!userToDelete} onOpenChange={(open) => !open && setUserToDelete(null)}>

--- a/packages/features/auth/lib/getServerSession.ts
+++ b/packages/features/auth/lib/getServerSession.ts
@@ -1,9 +1,11 @@
+import { parse, serialize } from "cookie";
 import { LRUCache } from "lru-cache";
-import type { GetServerSidePropsContext, NextApiRequest } from "next";
+import type { GetServerSidePropsContext, NextApiRequest, NextApiResponse } from "next";
 import type { AuthOptions, Session } from "next-auth";
 import { getToken } from "next-auth/jwt";
 
 import { LicenseKeySingleton } from "@calcom/ee/common/server/LicenseKeyService";
+import { WEBAPP_URL } from "@calcom/lib/constants";
 import { getUserAvatarUrl } from "@calcom/lib/getAvatarUrl";
 import logger from "@calcom/lib/logger";
 import { safeStringify } from "@calcom/lib/safeStringify";
@@ -17,6 +19,7 @@ const log = logger.getSubLogger({ prefix: ["getServerSession"] });
  *
  */
 const CACHE = new LRUCache<string, Session>({ max: 1000 });
+const LAST_ACTIVE_CACHE = new LRUCache<number, true>({ max: 10000, ttl: 12 * 60 * 60 * 1000 });
 
 /**
  * This is a slimmed down version of the `getServerSession` function from
@@ -31,9 +34,10 @@ const CACHE = new LRUCache<string, Session>({ max: 1000 });
  */
 export async function getServerSession(options: {
   req: NextApiRequest | GetServerSidePropsContext["req"];
+  res?: NextApiResponse | GetServerSidePropsContext["res"];
   authOptions?: AuthOptions;
 }) {
-  const { req, authOptions: { secret } = {} } = options;
+  const { req, res, authOptions: { secret } = {} } = options;
 
   const token = await getToken({
     req,
@@ -45,6 +49,42 @@ export async function getServerSession(options: {
   if (!token || !token.email || !token.sub) {
     log.debug("Couldn't get token");
     return null;
+  }
+
+  const userId = Number(token.sub);
+  if (Number.isFinite(userId)) {
+    const cookieHeader = req.headers?.cookie ?? "";
+    const { last_active_throttle } = parse(cookieHeader);
+    if (!last_active_throttle && !LAST_ACTIVE_CACHE.has(userId)) {
+      try {
+        await prisma.user.update({
+          where: { id: userId },
+          data: { lastActiveAt: new Date() },
+        });
+        LAST_ACTIVE_CACHE.set(userId, true);
+        if (res) {
+          const useSecureCookies = WEBAPP_URL?.startsWith("https://");
+          const cookieValue = serialize("last_active_throttle", "1", {
+            httpOnly: true,
+            sameSite: "lax",
+            secure: useSecureCookies,
+            path: "/",
+            maxAge: 12 * 60 * 60,
+          });
+          const existing = res.getHeader("Set-Cookie");
+          if (existing) {
+            res.setHeader(
+              "Set-Cookie",
+              Array.isArray(existing) ? [...existing, cookieValue] : [existing, cookieValue]
+            );
+          } else {
+            res.setHeader("Set-Cookie", [cookieValue]);
+          }
+        }
+      } catch (error) {
+        log.debug("Failed to update lastActiveAt in getServerSession", safeStringify({ error }));
+      }
+    }
   }
 
   const cachedSession = CACHE.get(JSON.stringify(token));

--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -2,6 +2,7 @@ import ImpersonationProvider from "@calid/features/modules/impersonation/Imperso
 import { calendar_v3 } from "@googleapis/calendar";
 import type { Membership, Team, UserPermissionRole } from "@prisma/client";
 import { waitUntil } from "@vercel/functions";
+import { serialize } from "cookie";
 import { OAuth2Client } from "googleapis-common";
 import type { AuthOptions, Session, User } from "next-auth";
 import type { JWT } from "next-auth/jwt";
@@ -17,6 +18,7 @@ import { LicenseKeySingleton } from "@calcom/ee/common/server/LicenseKeyService"
 import createUsersAndConnectToOrg from "@calcom/features/ee/dsync/lib/users/createUsersAndConnectToOrg";
 import { getOrgFullOrigin, subdomainSuffix } from "@calcom/features/ee/organizations/lib/orgDomains";
 import { clientSecretVerifier, hostedCal, isSAMLLoginEnabled } from "@calcom/features/ee/sso/lib/saml";
+import { UsersRepository } from "@calcom/features/users/users.repository";
 import { checkRateLimitAndThrowError } from "@calcom/lib/checkRateLimitAndThrowError";
 import {
   GOOGLE_CALENDAR_SCOPES,
@@ -445,6 +447,7 @@ export const getOptions = ({
   cookies: Partial<{
     dub_id?: string;
     utm_params?: string;
+    last_active_throttle?: string;
   }>;
   res?: any;
 }): AuthOptions => ({
@@ -498,6 +501,26 @@ export const getOptions = ({
       account,
     }) {
       log.debug("callbacks:jwt", safeStringify({ token, user, account, trigger, session }));
+      if (token.id && !cookies.last_active_throttle && res) {
+        waitUntil(new UsersRepository().updateLastActiveAt(token.id as number));
+        const useSecureCookies = WEBAPP_URL?.startsWith("https://");
+        const cookieValue = serialize("last_active_throttle", "1", {
+          httpOnly: true,
+          sameSite: "lax",
+          secure: useSecureCookies,
+          path: "/",
+          maxAge: 12 * 60 * 60,
+        });
+        const existing = res.getHeader("Set-Cookie");
+        if (existing) {
+          res.setHeader(
+            "Set-Cookie",
+            Array.isArray(existing) ? [...existing, cookieValue] : [existing, cookieValue]
+          );
+        } else {
+          res.setHeader("Set-Cookie", [cookieValue]);
+        }
+      }
       // The data available in 'session' depends on what data was supplied in update method call of session
       if (trigger === "update") {
         return {

--- a/packages/trpc/server/routers/viewer/admin/calid/userSchemas.ts
+++ b/packages/trpc/server/routers/viewer/admin/calid/userSchemas.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { UserPermissionRole } from "@calcom/prisma/enums";
 import { _UserModel as User } from "@calcom/prisma/zod";
 
 export const userIdSchema = z.object({ userId: z.coerce.number() });
@@ -25,6 +26,17 @@ export const userUpdateSchema = userBodySchema.partial().extend({
   userId: z.coerce.number(),
 });
 
+export const userListSchema = z.object({
+  limit: z.number().min(1).max(100),
+  offset: z.number().min(0),
+  searchTerm: z.string().nullish(),
+  role: z.nativeEnum(UserPermissionRole).nullish(),
+  locked: z.boolean().nullish(),
+  sortBy: z.enum(["name", "email", "createdDate", "role"]).nullish(),
+  sortDir: z.enum(["asc", "desc"]).nullish(),
+});
+
 export type TUserIdSchema = z.infer<typeof userIdSchema>;
 export type TUserBodySchema = z.infer<typeof userBodySchema>;
 export type TUserUpdateSchema = z.infer<typeof userUpdateSchema>;
+export type TUserListSchema = z.infer<typeof userListSchema>;

--- a/packages/trpc/server/routers/viewer/admin/calid/usersRouter.ts
+++ b/packages/trpc/server/routers/viewer/admin/calid/usersRouter.ts
@@ -1,12 +1,13 @@
 import { WEBAPP_URL, WEBSITE_URL } from "@calcom/lib/constants";
 import prisma from "@calcom/prisma";
+import type { Prisma } from "@calcom/prisma/client";
 import { CreationSource, RedirectType } from "@calcom/prisma/enums";
 import { authedAdminProcedure } from "@calcom/trpc/server/procedures/authedProcedure";
 import { router } from "@calcom/trpc/server/trpc";
 
 import { TRPCError } from "@trpc/server";
 
-import { userBodySchema, userIdSchema, userUpdateSchema } from "./userSchemas";
+import { userBodySchema, userIdSchema, userListSchema, userUpdateSchema } from "./userSchemas";
 
 const subdomainSuffix = () => {
   const urlSplit = WEBAPP_URL.replace("https://", "").replace("http://", "").split(".");
@@ -38,6 +39,88 @@ export const calidAdminUsersRouter = router({
   list: authedAdminProcedure.query(async ({ ctx }) => {
     const users = await ctx.prisma.user.findMany();
     return users;
+  }),
+  listPaginated: authedAdminProcedure.input(userListSchema).query(async ({ ctx, input }) => {
+    const { limit, offset, searchTerm, role, locked, sortBy, sortDir } = input;
+
+    const whereFilters: Prisma.UserWhereInput = {
+      AND: [{ OR: [{ locked: false }, { locked: true }] }],
+    };
+
+    if (searchTerm) {
+      whereFilters.AND?.push({
+        OR: [
+          {
+            email: {
+              contains: searchTerm.toLowerCase(),
+            },
+          },
+          {
+            username: {
+              contains: searchTerm.toLowerCase(),
+            },
+          },
+          {
+            profiles: {
+              some: {
+                username: {
+                  contains: searchTerm.toLowerCase(),
+                },
+              },
+            },
+          },
+        ],
+      });
+    }
+
+    if (role) {
+      whereFilters.AND?.push({ role });
+    }
+
+    if (locked !== null && locked !== undefined) {
+      whereFilters.AND?.push({ locked });
+    }
+
+    const orderBy: Prisma.UserOrderByWithRelationInput[] = [];
+    if (sortBy && sortDir) {
+      orderBy.push({ [sortBy]: sortDir });
+    }
+    orderBy.push({ id: "asc" });
+
+    const [totalRowCount, users] = await Promise.all([
+      ctx.prisma.user.count({ where: whereFilters }),
+      ctx.prisma.user.findMany({
+        skip: offset,
+        take: limit,
+        where: whereFilters,
+        orderBy,
+        select: {
+          id: true,
+          locked: true,
+          email: true,
+          username: true,
+          name: true,
+          timeZone: true,
+          role: true,
+          createdDate: true,
+          lastActiveAt: true,
+          profiles: {
+            select: {
+              username: true,
+            },
+          },
+          whitelistWorkflows: true,
+          avatarUrl: true,
+        },
+      }),
+    ]);
+
+    return {
+      rows: users || [],
+      meta: {
+        totalRowCount: totalRowCount || 0,
+      },
+    };
   }),
   add: authedAdminProcedure.input(userBodySchema).mutation(async ({ ctx, input }) => {
     const user = await ctx.prisma.user.create({ data: { ...input, creationSource: CreationSource.WEBAPP } });


### PR DESCRIPTION
## Summary
- Add admin users filters, sorting, pagination, and new Created/Last Active columns in CalID admin users table.
- Add CalID admin users list endpoint with filtering/sorting and extra fields.
- Implement cookie-throttled `lastActiveAt` updates in NextAuth and server-side session checks.

## Notes
- `last_active_throttle` cookie TTL is 12 hours.
