### PR TITLE
fix: whatsapp header length truncating

### DIFF
--- a/packages/calid/modules/workflows/providers/meta.ts
+++ b/packages/calid/modules/workflows/providers/meta.ts
@@ -1,5 +1,10 @@
 // meta.ts
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
+
+import dayjs from "@calcom/dayjs";
 import type { Prisma } from "@prisma/client";
+
 
 import { checkSMSRateLimit } from "@calcom/lib/checkRateLimitAndThrowError";
 import { INNGEST_ID, META_API_VERSION } from "@calcom/lib/constants";
@@ -12,6 +17,11 @@ import { inngestClient } from "@calcom/web/pages/api/inngest";
 import { META_DYNAMIC_TEXT_VARIABLES } from "../config/constants";
 import type { VariablesType } from "../templates/customTemplate";
 import { defaultTemplateNamesMap, defaultTemplateComponentsMap } from "./meta_default_templates";
+
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
 
 // Meta error is retriable, other errors shouldn't be retried by inngest else we risk spamming
 export class MetaError extends Error {


### PR DESCRIPTION
`event_type_name` in the header will now get truncated to proper length that meta allows sending.
fix for timezone parsing when scheduled from cron.