### PR TITLE
fix: 759 phone number input limited to 8 digits for 225 country code

### DIFF
--- a/packages/calid/ui/components/input/phone-input.tsx
+++ b/packages/calid/ui/components/input/phone-input.tsx
@@ -8,7 +8,7 @@ import "react-phone-input-2/lib/style.css";
 
 import { trpc } from "@calcom/trpc/react";
 
-const CUSTOM_PHONE_MASKS = {
+export const CUSTOM_PHONE_MASKS = {
   ci: ".. .. .. .. ..",
   bj: ".. .. .. .. ..",
 };

--- a/packages/features/components/phone-input/PhoneInput.tsx
+++ b/packages/features/components/phone-input/PhoneInput.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { CUSTOM_PHONE_MASKS } from "@calid/features/ui/components/input/phone-input";
 import { isSupportedCountry } from "libphonenumber-js";
 import moment from "moment-timezone";
 import { useState, useEffect, useMemo } from "react";
@@ -61,6 +62,7 @@ function BasePhoneInput({
       disableSearchIcon
       country={defaultCountry}
       autoFormat={autoFormat}
+      masks={CUSTOM_PHONE_MASKS}
       inputProps={{
         name: name,
         required: rest.required,

--- a/packages/features/form-builder/Components.tsx
+++ b/packages/features/form-builder/Components.tsx
@@ -1,5 +1,5 @@
 import { Icon } from "@calid/features/ui/components/icon";
-import { PhoneInput } from "@calid/features/ui/components/input/phone-input";
+import PhoneInput from "@calcom/features/components/phone-input";
 import { AttachmentUploader, type AttachmentUploaderRef } from "@calid/features/ui/components/uploader";
 import { useEffect, useRef } from "react";
 import type { z } from "zod";


### PR DESCRIPTION
Closes #759 

Added custom masks to display +229 and +225 phone numbers properly.
Allowed proper input length as allowed by both countries.