### PR TITLE
fix: bookings not getting cancelled if associated event type not found for the booking.

### DIFF
--- a/packages/features/bookings/lib/handleCancelBooking.ts
+++ b/packages/features/bookings/lib/handleCancelBooking.ts
@@ -472,7 +472,9 @@ async function handler(input: CancelBookingInput) {
     : null;
   const eventType = { ...bookingToDelete.eventType, workflows: eventTypeRelated };
 
-  const workflows: CalIdWorkflow[] = eventType?.workflows?.map((workflow) => workflow as CalIdWorkflow);
+  const workflows: CalIdWorkflow[] = (eventType?.workflows ?? []).map(
+    (workflow) => workflow as CalIdWorkflow
+  );
 
   if (workflows.length > 0) {
     await sendCancelledReminders({


### PR DESCRIPTION
Fixes null reference error by setting empty array for workflows if no associated event-types are found for the booking.
Closes #767 