### PR TITLE
add:so-busy-toggle

### DIFF
--- a/apps/web/public/static/locales/en/common.json
+++ b/apps/web/public/static/locales/en/common.json
@@ -1301,6 +1301,8 @@
   "duplicate": "Duplicate",
   "offer_seats": "Offer seats",
   "offer_seats_description": "Offer seats for booking. This automatically disables guest & opt-in bookings.",
+  "so_busy_title": "So Busy",
+  "so_busy_description": "Show only half of available slots to bookers (randomized and stable).",
   "seats_available_one": "Seat available",
   "seats_available_other": "Seats available",
   "seats_nearly_full": "Seats almost full",

--- a/packages/calid/modules/event-types/components/tabs/event-types-advanced.tsx
+++ b/packages/calid/modules/event-types/components/tabs/event-types-advanced.tsx
@@ -1738,6 +1738,28 @@ export const EventAdvanced = ({
         </>
       )}
 
+      <Controller
+        name="metadata.soBusy"
+        render={({ field: { value, onChange } }) => (
+          <SettingsToggle
+            toggleSwitchAtTheEnd={true}
+            title={t("so_busy_title")}
+            description={t("so_busy_description")}
+            checked={!!value}
+            onCheckedChange={onChange}
+            fieldPermissions={fieldPermissions}
+            fieldName="metadata.soBusy"
+            lockedIcon={
+              <FieldPermissionIndicator
+                fieldName="metadata.soBusy"
+                fieldPermissions={fieldPermissions}
+                t={t}
+              />
+            }
+          />
+        )}
+      />
+
       {/* Event Name Customization Modal */}
       {showEventNameTip && (
         <CustomEventNameModal

--- a/packages/features/eventtypes/components/tabs/advanced/EventAdvancedTab.tsx
+++ b/packages/features/eventtypes/components/tabs/advanced/EventAdvancedTab.tsx
@@ -1421,6 +1421,22 @@ export const EventAdvancedTab = ({
           />
         </>
       )}
+
+      <Controller
+        name="metadata.soBusy"
+        render={({ field: { value, onChange } }) => (
+          <SettingsToggle
+            labelClassName={classNames("text-sm")}
+            toggleSwitchAtTheEnd={true}
+            switchContainerClassName={classNames("border-subtle rounded-lg border py-6 px-4 sm:px-6")}
+            title={t("so_busy_title")}
+            description={t("so_busy_description")}
+            checked={!!value}
+            onCheckedChange={(e) => onChange(e)}
+          />
+        )}
+      />
+
       {showEventNameTip && (
         <CustomEventTypeModal
           close={closeEventNameTip}

--- a/packages/platform/atoms/event-types/hooks/useEventTypeForm.ts
+++ b/packages/platform/atoms/event-types/hooks/useEventTypeForm.ts
@@ -103,7 +103,10 @@ export const useEventTypeForm = ({
       minimumBookingNotice: eventType.minimumBookingNotice,
       allowReschedulingPastBookings: eventType.allowReschedulingPastBookings,
       hideOrganizerEmail: eventType.hideOrganizerEmail,
-      metadata: eventType.metadata,
+      metadata: {
+        ...(eventType.metadata ?? {}),
+        soBusy: eventType.metadata?.soBusy ?? false,
+      },
       hosts: eventType.hosts.sort((a, b) => sortHosts(a, b, eventType.isRRWeightsEnabled)),
       successRedirectUrl: eventType.successRedirectUrl || "",
       forwardParamsSuccessRedirect: eventType.forwardParamsSuccessRedirect,

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -133,6 +133,7 @@ const _eventTypeMetaDataSchemaWithoutApps = z.object({
     .optional()
     .nullable(),
   billingAddressRequired: z.boolean().optional(),
+  soBusy: z.boolean().optional(),
 });
 
 export const eventTypeMetaDataSchemaWithUntypedApps = _eventTypeMetaDataSchemaWithoutApps.merge(

--- a/packages/trpc/server/routers/viewer/slots/util.ts
+++ b/packages/trpc/server/routers/viewer/slots/util.ts
@@ -1,4 +1,5 @@
 // eslint-disable-next-line no-restricted-imports
+import { createHash } from "crypto";
 import type { Logger } from "tslog";
 import { v4 as uuid } from "uuid";
 
@@ -67,6 +68,39 @@ const log = logger.getSubLogger({ prefix: ["[slots/util]"] });
 
 type GetAvailabilityUserWithDelegationCredentials = Omit<GetAvailabilityUser, "credentials"> & {
   credentials: CredentialForCalendarService[];
+};
+
+const getStableSlotScore = (eventTypeId: number, time: string) => {
+  const hash = createHash("sha256").update(`${eventTypeId}:${time}`).digest("hex");
+  return parseInt(hash.slice(0, 8), 16);
+};
+
+const applySoBusyFilter = <T extends { time: string }>(
+  slotsByDate: Record<string, T[]>,
+  eventTypeId: number
+) => {
+  const filtered: typeof slotsByDate = {};
+
+  for (const [date, slots] of Object.entries(slotsByDate)) {
+    if (!slots.length) continue;
+
+    const targetCount = Math.ceil(slots.length / 2);
+    const scored = slots
+      .map((slot) => ({
+        time: slot.time,
+        score: getStableSlotScore(eventTypeId, slot.time),
+      }))
+      .sort((a, b) => a.score - b.score);
+
+    const keep = new Set(scored.slice(0, targetCount).map((slot) => slot.time));
+    const keptSlots = slots.filter((slot) => keep.has(slot.time));
+
+    if (keptSlots.length) {
+      filtered[date] = keptSlots;
+    }
+  }
+
+  return filtered;
 };
 
 export interface IGetAvailableSlots {
@@ -1361,9 +1395,12 @@ export class AvailableSlotsService {
       "mapWithinBoundsSlotsToDate"
     );
     const withinBoundsSlotsMappedToDate = mapWithinBoundsSlotsToDate();
+    const finalSlotsMappedToDate = eventType.metadata?.soBusy
+      ? applySoBusyFilter(withinBoundsSlotsMappedToDate, eventType.id)
+      : withinBoundsSlotsMappedToDate;
 
     // We only want to run this on single targeted events and not dynamic
-    if (!Object.keys(withinBoundsSlotsMappedToDate).length && input.usernameList?.length === 1) {
+    if (!Object.keys(finalSlotsMappedToDate).length && input.usernameList?.length === 1) {
       try {
         // TODO: DI handleNotificationWhenNoSlots
         await handleNotificationWhenNoSlots({
@@ -1406,7 +1443,7 @@ export class AvailableSlotsService {
       : null;
 
     return {
-      slots: withinBoundsSlotsMappedToDate,
+      slots: finalSlotsMappedToDate,
       ...troubleshooterData,
     };
   }


### PR DESCRIPTION
## Summary
- Add “So Busy” toggle to event type Advanced settings.
- Persist toggle via event type metadata.
- Filter visible slots to a deterministic 50% when enabled (stable across users/refreshes).

## Notes
- Default behavior unchanged when toggle is off.
- Slot filtering happens server-side so it applies to web, embed, and API.