### PR TITLE
properly grouped build actions to prevent killing of untargted builds

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -27,7 +27,8 @@ on:
         default: "false"
 
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{github.event.inputs.branch || github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   # ONLY RUN JOB ON PR MERGE on MAIN OR DEVELOP BRANCH


### PR DESCRIPTION
Grouped build actions by target branch name to prevent killing of running actions of another target branches