### PR TITLE
fix: minor fix to avoid duplicate SMS on save

### DIFF
--- a/packages/trpc/server/routers/viewer/workflows/util.calid.ts
+++ b/packages/trpc/server/routers/viewer/workflows/util.calid.ts
@@ -726,6 +726,10 @@ export function isCalIdStepFieldsEdited(oldStep: CalIdWorkflowStep, newStep: Cal
   ] as const;
 
   for (const key of fieldsToCompare) {
+    if (key === "reminderBody" && newStep.template !== WorkflowTemplates.CUSTOM) {
+      continue;
+    }
+
     if (oldStep[key] !== newStep[key]) {
       return true;
     }


### PR DESCRIPTION
Fix for duplicate SMS sent on first save to workflow due to reminder body being sent different.