### PR TITLE
fixed:full name validation

### DIFF
--- a/apps/web/components/getting-started/steps-views/UserSettings.tsx
+++ b/apps/web/components/getting-started/steps-views/UserSettings.tsx
@@ -39,7 +39,8 @@ const UserSettings = (props: IUserSettingsProps) => {
       .min(1)
       .max(FULL_NAME_LENGTH_MAX_LIMIT, {
         message: t("max_limit_allowed_hint", { limit: FULL_NAME_LENGTH_MAX_LIMIT }),
-      }),
+      })
+      .regex(/^[a-zA-Z\u00C0-\u024F\u1E00-\u1EFF\s.'-]+$/, "Invalid name"),
   });
 
   const defaultValues = {

--- a/apps/web/modules/settings/my-account/profile-view.tsx
+++ b/apps/web/modules/settings/my-account/profile-view.tsx
@@ -545,7 +545,8 @@ const ProfileForm = ({
       .min(1, t("you_need_to_add_a_name"))
       .max(FULL_NAME_LENGTH_MAX_LIMIT, {
         message: t("max_limit_allowed_hint", { limit: FULL_NAME_LENGTH_MAX_LIMIT }),
-      }),
+      })
+      .regex(/^[a-zA-Z\u00C0-\u024F\u1E00-\u1EFF\s.'-]+$/, "Invalid name"),
     email: emailSchema,
     bio: z.string(),
     secondaryEmails: z.array(

--- a/packages/calid/modules/teams/pages/CreateNewTeam.tsx
+++ b/packages/calid/modules/teams/pages/CreateNewTeam.tsx
@@ -72,7 +72,13 @@ const CreateNewTeamPage = () => {
           <FormField
             name="name"
             control={formMethods.control}
-            rules={{ required: t("team_name_is_required") }}
+            rules={{
+              required: t("team_name_is_required"),
+              pattern: {
+                value: /^[a-zA-Z0-9\u00C0-\u024F\u1E00-\u1EFF\s.'-]+$/,
+                message: "Invalid team name",
+              },
+            }}
             render={({ field: { value, onChange }, fieldState: { error } }) => (
               <>
                 <TextField

--- a/packages/calid/modules/teams/settings/TeamProfileView.tsx
+++ b/packages/calid/modules/teams/settings/TeamProfileView.tsx
@@ -36,7 +36,7 @@ const regex = new RegExp("^[a-zA-Z0-9.-]*$");
 
 const teamProfileSchema = z.object({
   id: z.number(),
-  name: z.string(),
+  name: z.string().regex(/^[a-zA-Z0-9\u00C0-\u024F\u1E00-\u1EFF\s.'-]+$/, "Invalid team name"),
   slug: z
     .string()
     .regex(regex, {

--- a/packages/emails/src/components/WhoInfo.tsx
+++ b/packages/emails/src/components/WhoInfo.tsx
@@ -10,9 +10,20 @@ export const PersonInfo = ({ name = "", email = "", role = "", phoneNumber = "" 
   const displayEmail = !isSmsCalEmail(email);
   const formattedPhoneNumber = !!phoneNumber ? `${phoneNumber} ` : "";
 
+  // Escape HTML entities to prevent injection in email templates
+  let safeName = name
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+
+  // Break auto-linking by inserting zero-width space after periods
+  // This prevents email clients from converting "domain.com" into clickable links
+  safeName = safeName.replace(/\./g, ".\u200B");
+
   return (
     <div style={{ color: "#101010", fontWeight: 400, lineHeight: "24px" }}>
-      {name} - {role} {formattedPhoneNumber}
+      {safeName} - {role} {formattedPhoneNumber}
       {displayEmail && (
         <span style={{ color: "#4B5563" }}>
           <a href={`mailto:${email}`} style={{ color: "#4B5563" }}>

--- a/packages/lib/sanitizeName.ts
+++ b/packages/lib/sanitizeName.ts
@@ -1,0 +1,11 @@
+/**
+ * Sanitizes user name input to prevent URL/HTML injection
+ * This is a defense-in-depth measure alongside schema validation
+ */
+export function sanitizeName(name: string): string {
+  return name
+    .trim()
+    .replace(/[<>]/g, "") // Remove angle brackets to prevent HTML tags
+    .replace(/https?:\/\/[^\s]+/gi, "") // Remove URLs
+    .slice(0, 50); // Enforce max length as additional safety
+}

--- a/packages/trpc/server/routers/viewer/me/updateProfile.handler.ts
+++ b/packages/trpc/server/routers/viewer/me/updateProfile.handler.ts
@@ -10,6 +10,7 @@ import { FeaturesRepository } from "@calcom/features/flags/features.repository";
 import hasKeyInMetadata from "@calcom/lib/hasKeyInMetadata";
 import { HttpError } from "@calcom/lib/http-error";
 import logger from "@calcom/lib/logger";
+import { sanitizeName } from "@calcom/lib/sanitizeName";
 import { uploadLogo, uploadHeader } from "@calcom/lib/server/avatar";
 import { uploadAvatar } from "@calcom/lib/server/avatar";
 import { checkUsername } from "@calcom/lib/server/checkUsername";
@@ -48,6 +49,11 @@ export const updateProfileHandler = async ({ ctx, input }: UpdateProfileOptions)
 
   const secondaryEmails = input?.secondaryEmails || [];
   delete input.secondaryEmails;
+
+  // Sanitize name field as defense-in-depth security measure
+  if (input.name) {
+    input.name = sanitizeName(input.name);
+  }
 
   const data: Prisma.UserUpdateInput = {
     ...rest,

--- a/packages/trpc/server/routers/viewer/me/updateProfile.schema.ts
+++ b/packages/trpc/server/routers/viewer/me/updateProfile.schema.ts
@@ -15,7 +15,15 @@ export const updateUserMetadataAllowedKeys = z.object({
 
 export const ZUpdateProfileInputSchema = z.object({
   username: z.string().optional(),
-  name: z.string().max(FULL_NAME_LENGTH_MAX_LIMIT).optional(),
+  name: z
+    .string()
+    .max(FULL_NAME_LENGTH_MAX_LIMIT)
+    .regex(
+      /^[a-zA-Z\u00C0-\u024F\u1E00-\u1EFF\s.'-]+$/,
+      "Name can only contain letters, spaces, periods, hyphens, and apostrophes"
+    )
+    .trim()
+    .optional(),
   email: z.string().optional(),
   bio: z.string().optional(),
   avatarUrl: z.string().nullable().optional(),

--- a/packages/trpc/server/routers/viewer/teams/create.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/create.handler.ts
@@ -1,5 +1,6 @@
 import { generateTeamCheckoutSession } from "@calcom/features/ee/teams/lib/payments";
 import { IS_TEAM_BILLING_ENABLED, WEBAPP_URL } from "@calcom/lib/constants";
+import { sanitizeName } from "@calcom/lib/sanitizeName";
 import { uploadLogo } from "@calcom/lib/server/avatar";
 import { ProfileRepository } from "@calcom/lib/server/repository/profile";
 import { resizeBase64Image } from "@calcom/lib/server/resizeBase64Image";
@@ -48,7 +49,11 @@ const generateCheckoutSession = async ({
 
 export const createHandler = async ({ ctx, input }: CreateOptions) => {
   const { user } = ctx;
-  const { slug, name } = input;
+  const { slug } = input;
+
+  // Sanitize team name as defense-in-depth security measure
+  const name = sanitizeName(input.name);
+
   const isOrgChildTeam = !!user.profile?.organizationId;
 
   // For orgs we want to create teams under the org

--- a/packages/trpc/server/routers/viewer/teams/create.schema.ts
+++ b/packages/trpc/server/routers/viewer/teams/create.schema.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import slugify from "@calcom/lib/slugify";
 
 export const ZCreateInputSchema = z.object({
-  name: z.string(),
+  name: z.string().regex(/^[a-zA-Z0-9\u00C0-\u024F\u1E00-\u1EFF\s.'-]+$/, "Invalid team name"),
   slug: z.string().transform((val) => slugify(val.trim())),
   logo: z
     .string()

--- a/packages/trpc/server/routers/viewer/teams/update.handler.ts
+++ b/packages/trpc/server/routers/viewer/teams/update.handler.ts
@@ -4,6 +4,7 @@ import { getOrgFullOrigin } from "@calcom/ee/organizations/lib/orgDomains";
 import { IS_TEAM_BILLING_ENABLED } from "@calcom/lib/constants";
 import type { IntervalLimit } from "@calcom/lib/intervalLimits/intervalLimitSchema";
 import { validateIntervalLimitOrder } from "@calcom/lib/intervalLimits/validateIntervalLimitOrder";
+import { sanitizeName } from "@calcom/lib/sanitizeName";
 import { uploadLogo } from "@calcom/lib/server/avatar";
 import { isTeamAdmin } from "@calcom/lib/server/queries/teams";
 import { prisma } from "@calcom/prisma";
@@ -54,8 +55,11 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
       throw new TRPCError({ code: "BAD_REQUEST", message: "Booking limits must be in ascending order." });
   }
 
+  // Sanitize team name if provided
+  const sanitizedName = input.name ? sanitizeName(input.name) : undefined;
+
   const data: Prisma.TeamUpdateArgs["data"] = {
-    name: input.name,
+    name: sanitizedName,
     bio: input.bio,
     hideBranding: input.hideBranding,
     isPrivate: input.isPrivate,

--- a/packages/trpc/server/routers/viewer/teams/update.schema.ts
+++ b/packages/trpc/server/routers/viewer/teams/update.schema.ts
@@ -27,7 +27,10 @@ export type TUpdateInputSchema = {
 export const ZUpdateInputSchema: z.Schema<TUpdateInputSchema> = z.object({
   id: z.number(),
   bio: z.string().optional(),
-  name: z.string().optional(),
+  name: z
+    .string()
+    .regex(/^[a-zA-Z0-9\u00C0-\u024F\u1E00-\u1EFF\s.'-]+$/, "Invalid team name")
+    .optional(),
   logo: z
     .string()
     .transform(async (val) => await resizeBase64Image(val))


### PR DESCRIPTION
## Security Fix: URL/HTML Injection in Name Fields

### Problem
User and team name fields accepted malicious URLs and HTML, which rendered as clickable links in booking emails, enabling phishing attacks.

### Solution
Implemented multi-layer validation to block URLs and HTML while allowing legitimate names with international characters, hyphens, apostrophes, and periods.

### Changes
1. Created `sanitizeName()` utility to strip URLs, HTML tags, and enforce length limits
2. Added regex validation `/^[a-zA-Z\u00C0-\u024F\u1E00-\u1EFF\s.'-]+$/` to backend schemas
3. Applied sanitization in all user/team name update handlers
4. Added frontend validation with error messages
5. Escaped HTML entities in email templates and prevented auto-linking