### PR TITLE
fix: Booking expanded card background and border disrupting visibility in dark mode

### DIFF
--- a/apps/web/components/booking/BookingExpandedCard.tsx
+++ b/apps/web/components/booking/BookingExpandedCard.tsx
@@ -112,7 +112,7 @@ export function BookingExpandedCard(props: BookingItemProps) {
   return (
     <>
       <div
-        className="animate-fade-in border-muted rounded-b-lg border-t bg-gray-50"
+        className="animate-fade-in bg-default border-default rounded-b-lg border-t"
         onClick={(e) => e.stopPropagation()}>
         <div className="grid grid-cols-1 gap-4 p-4 lg:grid-cols-2 lg:gap-8">
           <div className="space-y-4">


### PR DESCRIPTION
## What does this PR do?

- Fixes text visibility of content in booking expanded card not being visible due to gray background. The expanded card element now takes default background and border