### PR TITLE
fixed:limit tab toggle

### DIFF
--- a/packages/calid/modules/event-types/components/tabs/event-types-limit.tsx
+++ b/packages/calid/modules/event-types/components/tabs/event-types-limit.tsx
@@ -340,11 +340,9 @@ const RangeLimitRadioItem = memo(
     watchPeriodTypeUiValue: IPeriodType;
   }) => {
     const { t } = useLocale();
-    const [dateRange, setDateRange] = useState<{ startDate?: Date; endDate?: Date } | undefined>();
 
     const handleDateChange = useCallback(
       ({ startDate, endDate }: { startDate?: Date; endDate?: Date }, onChange: (value: any) => void) => {
-        setDateRange({ startDate, endDate });
         onChange({
           startDate,
           endDate,
@@ -364,10 +362,10 @@ const RangeLimitRadioItem = memo(
           <div className="ml-6 mt-2">
             <Controller
               name="periodDates"
-              render={({ field: { onChange } }) => (
+              render={({ field: { onChange, value } }) => (
                 <div className="w-fit">
                   <DateRangePicker
-                    dates={dateRange || { startDate: undefined, endDate: undefined }}
+                    dates={value || { startDate: undefined, endDate: undefined }}
                     onDatesChange={(dates) => handleDateChange(dates, onChange)}
                     disabled={isDisabled}
                     minDate={new Date()}


### PR DESCRIPTION
## Summary
- Fix Limits tab “Limit future bookings” date range display after refresh by binding the date range picker to saved form values.