### PR TITLE
fix: ensure truncated string length does not exceed maxLength includi…

### DIFF
--- a/packages/calid/modules/workflows/managers/smsManager.ts
+++ b/packages/calid/modules/workflows/managers/smsManager.ts
@@ -22,7 +22,7 @@ const moduleLogger = logger.getSubLogger({ prefix: ["[smsReminderManager]"] });
 
 /**
  * Mapping of workflow templates to their default message templates
- * Uses numbered placeholders: {{1}}, {{2}}, {{3}}, {{4}}, {{5}}
+ * Uses numbered placeholders: {{1}}, {{2}}, {{3}}, {{4}}, {{5}}, {{6}}
  * {{1}} - Recipient's Name
  * {{2}} - Meeting Title
  * {{3}} - Sender's Name

--- a/packages/calid/modules/workflows/utils/getTruncatedString.tsx
+++ b/packages/calid/modules/workflows/utils/getTruncatedString.tsx
@@ -1,43 +1,36 @@
 export default function wordTruncate(text: string, maxLength = 40) {
-  if (text.length <= maxLength + 3 /* exclude ellipsis when comparing original text length */) {
+  if (text.length <= maxLength) {
     return text;
   }
 
-  // Check if text contains spaces or hyphens
+  const ellipsis = "...";
+  const allowedLength = maxLength - ellipsis.length;
+
   const hasSpaces = text.includes(" ");
   const hasHyphens = text.includes("-");
 
   if (!hasSpaces && !hasHyphens) {
-    // No delimiters, just truncate by character count
-    return `${text.slice(0, maxLength)}...`;
+    return text.slice(0, allowedLength) + ellipsis;
   }
 
-  // Determine delimiter (prioritize spaces over hyphens)
   const delimiter = hasSpaces ? " " : "-";
-
-  // Split by delimiter and build truncated string word by word
   const words = text.split(delimiter);
+
   let result = "";
 
   for (let i = 0; i < words.length; i++) {
     const candidate = i === 0 ? words[i] : result + delimiter + words[i];
 
-    if (candidate.length > maxLength) {
+    if (candidate.length > allowedLength) {
       break;
     }
+
     result = candidate;
   }
 
-  // If we couldn't fit even the first word, truncate by character
   if (!result) {
-    return `${text.slice(0, maxLength)}...`;
+    return text.slice(0, allowedLength) + ellipsis;
   }
 
-  // Remove trailing delimiter and any non-alphabetic characters at the end
-  result = result.replace(/[^a-zA-Z]+$/, "");
-
-  // Remove leading non-alphabetic characters at the beginning
-  result = result.replace(/^[^a-zA-Z]+/, "");
-
-  return `${result}...`;
+  return result + ellipsis;
 }


### PR DESCRIPTION
This PR fixes issues in the `wordTruncate` utility:

1. **Ensures final truncated string (including `...`) does not exceed `maxLength`**
2. **Preserves numeric titles and special characters**
   * Removed overly aggressive regex cleanup that stripped numeric characters (e.g., `1:1`, `30 Min`).
   * Titles containing numbers and symbols are now handled correctly.