### PR TITLE
Fix routing form broken add button

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -41205,7 +41205,7 @@ __metadata:
 
 "react-awesome-query-builder@npm:^5.1.2":
   version: 5.4.0
-  resolution: "react-awesome-query-builder@npm:5.4.0"
+  resolution: "react-awesome-query-builder@npm:5.1.2"
   dependencies:
     "@date-io/moment": ^1.3.13
     classnames: ^2.3.1
@@ -41239,7 +41239,7 @@ __metadata:
     react: ^16.8.4 || ^17.0.1 || ^18.0.0
     react-dom: ^16.8.4 || ^17.0.1 || ^18.0.0
     reactstrap: ^9.0.0
-  checksum: 96f97b94c6544549e9d0991cec3f7753db722066ed2c24ba75cc0c8f90f2b04ab7f338c6a4a124bac78a0916c53ea864af4382ecb552e283602941c40ae9a035
+  checksum: 6efab0fcbb98d4843fbe3b5036a7831fd097774869fc0e175ca40c4770d7939dd3efcb2c3365c6fe539c8ba6b6bb19ddef55d93f491770a9bfdc3f1355cc5e4e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reverted `react-awesome-query-builder` version to older working one `react-awesome-query-builder@npm:5.4.0` -> `react-awesome-query-builder@npm:5.1.2`.