### PR TITLE
fix: Readded generate brand color styles that were removed

### DIFF
--- a/apps/web/modules/team/calid-team-public-view.tsx
+++ b/apps/web/modules/team/calid-team-public-view.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { generateBrandColorStyles } from "@calcom/lib/getBrandColours";
 
 import { getDefaultAvatar } from "@calid/features/lib/defaultAvatar";
 import { Branding } from "@calid/features/ui/Branding";
@@ -202,6 +203,12 @@ function TeamPage({ team, considerUnpublished, isValidOrgDomain, headerUrl }: Pa
 
   return (
     <div className="bg-default flex min-h-screen w-full flex-col">
+      <style
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{
+          __html: generateBrandColorStyles(team?.brandColor, team?.darkBrandColor),
+        }}
+      />
       <main className="bg-default h-full w-full">
         <div
           className="border-subtle bg-cal-gradient text-default mb-4 flex flex-col items-center bg-cover bg-center p-4"

--- a/apps/web/modules/users/views/users-public-view.tsx
+++ b/apps/web/modules/users/views/users-public-view.tsx
@@ -14,6 +14,7 @@ import type { z } from "zod";
 import { sdkActionManager, useEmbedNonStylesConfig, useIsEmbed } from "@calcom/embed-core/embed-iframe";
 import { EventTypeDescriptionLazy as EventTypeDescription } from "@calcom/features/eventtypes/components";
 import EmptyPage from "@calcom/features/eventtypes/components/EmptyPage";
+import { generateBrandColorStyles } from "@calcom/lib/getBrandColours";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { useRouterQuery } from "@calcom/lib/hooks/useRouterQuery";
 import { markdownToSafeHTML } from "@calcom/lib/markdownToSafeHTML";
@@ -117,6 +118,12 @@ export function UserPage(props: PageProps) {
           isEmbed ? "max-w-3xl" : "",
           "bg-default flex min-h-screen w-full flex-col"
         )}>
+        <style
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{
+            __html: generateBrandColorStyles(profile?.brandColor, profile?.darkBrandColor),
+          }}
+        />
         <main
           className={classNames(
             shouldAlignCentrally ? "mx-auto" : "",


### PR DESCRIPTION
closes #945 

Brand color generation method was removed from the React DOM along with removal of `<Head>` component. Readded the required method.