### PR TITLE
fix: idenfying public page hook

### DIFF
--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -11,7 +11,7 @@ import { WebPushProvider } from "@calcom/features/notifications/WebPushContext";
 import { NotificationSoundHandler } from "@calcom/web/components/notification-sound-handler";
 
 import CustomerEngagementProvider from "@lib/customerEngagementProvider";
-import useIsBookingPage from "@lib/hooks/useIsBookingPage";
+import useIsPublicPage from "@lib/hooks/useIsPublicPage";
 
 import { queryClient } from "./_trpc/query-client";
 
@@ -21,7 +21,7 @@ type ProvidersProps = {
   nonce: string | undefined;
 };
 export function Providers({ isEmbed, children, nonce: _nonce }: ProvidersProps) {
-  const isBookingPage = useIsBookingPage();
+  const isBookingPage = useIsPublicPage();
 
   useEffect(() => {
     if (isBookingPage) {

--- a/apps/web/lib/app-providers-app-dir.tsx
+++ b/apps/web/lib/app-providers-app-dir.tsx
@@ -14,7 +14,7 @@ import DynamicHelpscoutProvider from "@calcom/features/ee/support/lib/helpscout/
 import { FeatureProvider } from "@calcom/features/flags/context/provider";
 import { useFlags } from "@calcom/features/flags/hooks";
 
-import useIsBookingPage from "@lib/hooks/useIsBookingPage";
+import useIsPublicPage from "@lib/hooks/useIsPublicPage";
 import useIsThemeSupported from "@lib/hooks/useIsThemeSupported";
 import type { WithLocaleProps } from "@lib/withLocale";
 
@@ -107,7 +107,7 @@ function OrgBrandProvider({ children }: { children: React.ReactNode }) {
 
 const AppProviders = (props: PageWrapperProps) => {
   // No need to have intercom on public pages - Good for Page Performance
-  const isBookingPage = useIsBookingPage();
+  const isBookingPage = useIsPublicPage();
   const isThemeSupported = useIsThemeSupported();
 
   const RemainingProviders = (

--- a/apps/web/lib/app-providers.tsx
+++ b/apps/web/lib/app-providers.tsx
@@ -18,7 +18,7 @@ import DynamicHelpscoutProvider from "@calcom/features/ee/support/lib/helpscout/
 import { FeatureProvider } from "@calcom/features/flags/context/provider";
 import { useFlags } from "@calcom/features/flags/hooks";
 
-import useIsBookingPage from "@lib/hooks/useIsBookingPage";
+import useIsPublicPage from "@lib/hooks/useIsPublicPage";
 import type { WithLocaleProps } from "@lib/withLocale";
 
 import { useViewerI18n } from "@components/I18nLanguageHandler";
@@ -270,7 +270,7 @@ function OrgBrandProvider({ children }: { children: React.ReactNode }) {
 }
 
 const AppProviders = (props: AppPropsWithChildren) => {
-  const isBookingPage = useIsBookingPage();
+  const isBookingPage = useIsPublicPage();
 
   const RemainingProviders = (
     <EventCollectionProvider options={{ apiPath: "/api/collect-events" }}>

--- a/apps/web/lib/hooks/useIsPublicPage.ts
+++ b/apps/web/lib/hooks/useIsPublicPage.ts
@@ -2,14 +2,14 @@ import { usePathname } from "next/navigation";
 
 import { useCompatSearchParams } from "@calcom/lib/hooks/useCompatSearchParams";
 
-export default function useIsBookingPage(): boolean {
+export default function useIsPublicPage(): boolean {
   const pathname = usePathname();
   const isBookingPage = [
-    "/booking",
+    "/booking/",
     "/cancel",
     "/reschedule",
     "/instant-meeting", // Instant booking page
-    "/team", // Team booking pages
+    "/team/", // Team booking pages
     "/d", // Private Link of booking page
     "/apps/routing-forms/routing-link", // Routing Form page
     "/forms/", // Rewrites to /apps/routing-forms/routing-link


### PR DESCRIPTION
Fixes chat support widget not loading directly on dashboard bookings or teams page