### PR TITLE
Fix conferencing provider mismatch: organizer-aware retry + Jitsi default fallback + metadata/UI consistency

### DIFF
--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -18,7 +18,11 @@ import { flushSync } from "react-dom";
 import { Controller, useFieldArray, useForm } from "react-hook-form";
 
 import type { getEventLocationValue } from "@calcom/app-store/locations";
-import { getSuccessPageLocationMessage, guessEventLocationType } from "@calcom/app-store/locations";
+import {
+  getEventLocationTypeFromVideoProvider,
+  getSuccessPageLocationMessage,
+  guessEventLocationType,
+} from "@calcom/app-store/locations";
 import dayjs from "@calcom/dayjs";
 import "@calcom/dayjs/locales";
 import { Dialog } from "@calcom/features/components/controlled-dialog";
@@ -231,7 +235,9 @@ export default function BookingListItem(booking: BookingItemProps) {
     t,
     booking.status
   );
-  const provider = guessEventLocationType(location);
+  const provider =
+    getEventLocationTypeFromVideoProvider(parsedBooking.metadata?.videoProvider) ||
+    guessEventLocationType(location);
 
   const isDisabledCancelling = booking.eventType.disableCancelling;
   const isDisabledRescheduling = booking.eventType.disableRescheduling;

--- a/apps/web/modules/bookings/views/bookings-single-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-single-view.tsx
@@ -19,7 +19,11 @@ import { z } from "zod";
 
 import BookingPageTagManager from "@calcom/app-store/BookingPageTagManager";
 import type { getEventLocationValue } from "@calcom/app-store/locations";
-import { getSuccessPageLocationMessage, guessEventLocationType } from "@calcom/app-store/locations";
+import {
+  getEventLocationTypeFromVideoProvider,
+  getSuccessPageLocationMessage,
+  guessEventLocationType,
+} from "@calcom/app-store/locations";
 import { getEventTypeAppData } from "@calcom/app-store/utils";
 import dayjs from "@calcom/dayjs";
 import {
@@ -139,6 +143,7 @@ export default function Success(props: PageProps) {
     metadata: parsedBookingMetadata,
   };
   const locationVideoCallUrl = bookingWithParsedMetadata.metadata?.videoCallUrl;
+  const resolvedVideoProvider = bookingWithParsedMetadata.metadata?.videoProvider;
 
   const status = bookingInfo?.status;
   const reschedule = bookingInfo.status === BookingStatus.ACCEPTED;
@@ -357,7 +362,9 @@ export default function Success(props: PageProps) {
     bookingInfo.status
   );
 
-  const providerName = guessEventLocationType(location)?.label;
+  const providerName =
+    getEventLocationTypeFromVideoProvider(resolvedVideoProvider)?.label ||
+    guessEventLocationType(location)?.label;
   const rescheduleProviderName = guessEventLocationType(rescheduleLocation)?.label;
   const isBookingInPast = new Date(bookingInfo.endTime) < new Date();
   const isReschedulable = !isCancelled;

--- a/packages/app-store/jitsivideo/lib/VideoApiAdapter.ts
+++ b/packages/app-store/jitsivideo/lib/VideoApiAdapter.ts
@@ -1,11 +1,27 @@
 import { v4 as uuidv4 } from "uuid";
 
 import type { CalendarEvent } from "@calcom/types/Calendar";
+import type { CredentialForCalendarService } from "@calcom/types/Credential";
 import type { PartialReference } from "@calcom/types/EventManager";
 import type { VideoApiAdapter, VideoCallData } from "@calcom/types/VideoApiAdapter";
 
 import getAppKeysFromSlug from "../../_utils/getAppKeysFromSlug";
 import { metadata } from "../_metadata";
+
+export const FAKE_JITSI_CREDENTIAL: CredentialForCalendarService & { invalid: boolean } = {
+  id: 0,
+  type: "jitsi_video",
+  key: {},
+  userId: 0,
+  user: { email: "" },
+  appId: "jitsi",
+  invalid: false,
+  calIdTeamId: null,
+  teamId: null,
+  delegatedToId: null,
+  delegatedTo: null,
+  delegationCredentialId: null,
+};
 
 const JitsiVideoApiAdapter = (): VideoApiAdapter => {
   return {

--- a/packages/app-store/locations.ts
+++ b/packages/app-store/locations.ts
@@ -61,6 +61,8 @@ export const DailyLocationType = "integrations:daily";
 
 export const JitsiLocationType = "integrations:jitsi";
 
+export const DefaultFallbackVideoLocationType = JitsiLocationType;
+
 export const MeetLocationType = "integrations:google:meet";
 
 /**
@@ -280,6 +282,44 @@ const getStaticLinkLocationByValue = (value: string | undefined | null) => {
 
 export const guessEventLocationType = (locationTypeOrValue: string | undefined | null) =>
   getEventLocationType(locationTypeOrValue) || getStaticLinkLocationByValue(locationTypeOrValue);
+
+export const getEventLocationTypeFromVideoProvider = (videoProvider: string | undefined | null) => {
+  if (!videoProvider) {
+    return null;
+  }
+
+  const normalizedProvider = videoProvider.trim();
+  const providerCandidates = new Set<string>([normalizedProvider, `integrations:${normalizedProvider}`]);
+
+  if (normalizedProvider === "daily_video") {
+    providerCandidates.add(DailyLocationType);
+  }
+
+  if (normalizedProvider === "jitsi_video") {
+    providerCandidates.add(JitsiLocationType);
+  }
+
+  if (normalizedProvider === "google_meet_video") {
+    providerCandidates.add(MeetLocationType);
+  }
+
+  if (normalizedProvider.endsWith("_video")) {
+    providerCandidates.add(`integrations:${normalizedProvider.replace(/_video$/, "")}`);
+  }
+
+  if (normalizedProvider.endsWith("_conferencing")) {
+    providerCandidates.add(`integrations:${normalizedProvider.replace(/_conferencing$/, "")}`);
+  }
+
+  for (const candidate of providerCandidates) {
+    const eventLocationType = getEventLocationType(candidate);
+    if (eventLocationType) {
+      return eventLocationType;
+    }
+  }
+
+  return null;
+};
 
 export const LocationType = { ...DefaultEventLocationTypeEnum, ...AppStoreLocationType };
 

--- a/packages/calid/modules/home/components/MeetingsCard.tsx
+++ b/packages/calid/modules/home/components/MeetingsCard.tsx
@@ -6,7 +6,11 @@ import { Tooltip } from "@calid/features/ui/components/tooltip";
 import React, { useMemo, useState } from "react";
 
 import type { getEventLocationValue } from "@calcom/app-store/locations";
-import { getSuccessPageLocationMessage, guessEventLocationType } from "@calcom/app-store/locations";
+import {
+  getEventLocationTypeFromVideoProvider,
+  getSuccessPageLocationMessage,
+  guessEventLocationType,
+} from "@calcom/app-store/locations";
 import dayjs from "@calcom/dayjs";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
@@ -80,7 +84,9 @@ function transformBookingToMeeting(
     t,
     booking.status
   );
-  const provider = guessEventLocationType(location);
+  const provider =
+    getEventLocationTypeFromVideoProvider(booking.metadata?.videoProvider) ||
+    guessEventLocationType(location);
 
   const isUrl = typeof locationToDisplay === "string" && locationToDisplay.startsWith("http");
 

--- a/packages/calid/modules/teams/lib/handleRescheduleEventManager.ts
+++ b/packages/calid/modules/teams/lib/handleRescheduleEventManager.ts
@@ -108,7 +108,8 @@ export const roundRobinReschedulingManager = async ({
 
       const meetingLink = Array.isArray(calendarProviderResult?.updatedEvent)
         ? calendarProviderResult.updatedEvent[0]?.hangoutLink
-        : calendarProviderResult?.updatedEvent?.hangoutLink ?? calendarProviderResult?.createdEvent?.hangoutLink;
+        : calendarProviderResult?.updatedEvent?.hangoutLink ??
+          calendarProviderResult?.createdEvent?.hangoutLink;
 
       if (meetingLink) {
         rescheduleResults.push({
@@ -134,17 +135,20 @@ export const roundRobinReschedulingManager = async ({
         });
       }
     }
-    
+
     const primaryEventResult = Array.isArray(rescheduleResults[0]?.updatedEvent)
       ? rescheduleResults[0]?.updatedEvent[0]
       : rescheduleResults[0]?.updatedEvent ?? rescheduleResults[0]?.createdEvent;
-    
+
     additionalInfo.hangoutLink = primaryEventResult?.hangoutLink;
     additionalInfo.conferenceData = primaryEventResult?.conferenceData;
     additionalInfo.entryPoints = primaryEventResult?.entryPoints;
 
     finalVideoUrl =
-      additionalInfo.hangoutLink || primaryEventResult?.url || getVideoCallUrlFromCalEvent(evt) || finalVideoUrl;
+      additionalInfo.hangoutLink ||
+      primaryEventResult?.url ||
+      getVideoCallUrlFromCalEvent(evt) ||
+      finalVideoUrl;
 
     const calendarEventResult = rescheduleResults.find((result) => result.type.includes("_calendar"));
 
@@ -152,7 +156,7 @@ export const roundRobinReschedulingManager = async ({
       ? calendarEventResult?.updatedEvent[0]?.iCalUID
       : calendarEventResult?.updatedEvent?.iCalUID || undefined;
   }
-  
+
   const clonedReferences = structuredClone(rescheduleManager.referencesToCreate);
 
   await BookingReferenceRepository.replaceBookingReferences({
@@ -165,11 +169,18 @@ export const roundRobinReschedulingManager = async ({
       finalVideoUrl = bookingLocation;
     }
 
-    const updatedMetadata = finalVideoUrl
-      ? {
-          videoCallUrl: getVideoCallUrlFromCalEvent(evt) || finalVideoUrl,
-        }
-      : undefined;
+    const resolvedVideoProvider = evt.videoCallData?.type;
+    const updatedMetadata =
+      finalVideoUrl || resolvedVideoProvider
+        ? {
+            ...(finalVideoUrl
+              ? {
+                  videoCallUrl: getVideoCallUrlFromCalEvent(evt) || finalVideoUrl,
+                }
+              : {}),
+            ...(resolvedVideoProvider ? { videoProvider: resolvedVideoProvider } : {}),
+          }
+        : undefined;
 
     await prisma.booking.update({
       where: {

--- a/packages/calid/modules/teams/lib/roundRobinManualReassignment.ts
+++ b/packages/calid/modules/teams/lib/roundRobinManualReassignment.ts
@@ -1,7 +1,11 @@
 // eslint-disable-next-line no-restricted-imports
 import { cloneDeep } from "lodash";
 
-import { OrganizerDefaultConferencingAppType, getLocationValueForDB } from "@calcom/app-store/locations";
+import {
+  DefaultFallbackVideoLocationType,
+  OrganizerDefaultConferencingAppType,
+  getLocationValueForDB,
+} from "@calcom/app-store/locations";
 import dayjs from "@calcom/dayjs";
 import {
   sendRoundRobinCancelledEmailsAndSMS as RRCancelledEmailAndSMS,
@@ -271,7 +275,7 @@ async function determineLocationForNewOrganizer(
 
   const targetMeta = userMetadata.safeParse(data.targetHost.user.metadata);
   const defaultApp = targetMeta.success ? targetMeta.data?.defaultConferencingApp?.appLink : undefined;
-  const currentLoc = data.booking.location || "integrations:daily";
+  const currentLoc = data.booking.location || DefaultFallbackVideoLocationType;
 
   return defaultApp || getLocationValueForDB(currentLoc, data.eventType.locations).bookingLocation;
 }
@@ -291,7 +295,7 @@ async function generateBookingTitle(
     eventName: data.eventType.eventName,
     teamName: data.eventType.team?.name,
     host: data.targetHost.user.name || "Nameless",
-    location: location || "integrations:daily",
+    location: location || DefaultFallbackVideoLocationType,
     bookingFields: { ...responses },
     eventDuration: durationMinutes,
     t: targetTranslation,
@@ -451,7 +455,7 @@ async function synchronizeCalendars(
     bookingICalUID: updatedBooking.iCalUID,
     bookingMetadata: updatedBooking.metadata,
   });
-  console.log("Event after sync: ", evtWithAdditionalInfo)
+  console.log("Event after sync: ", evtWithAdditionalInfo);
 
   return evtWithAdditionalInfo;
 }
@@ -641,7 +645,7 @@ async function fetchActiveReminders(booking: BookingSelectResult): Promise<any[]
     WorkflowTriggerEvents.AFTER_EVENT,
   ];
 
-  const bookingUid = booking.uid
+  const bookingUid = booking.uid;
 
   return await prisma.calIdWorkflowReminder.findMany({
     where: {

--- a/packages/calid/modules/teams/lib/roundRobinReassignUser.ts
+++ b/packages/calid/modules/teams/lib/roundRobinReassignUser.ts
@@ -1,7 +1,11 @@
 // eslint-disable-next-line no-restricted-imports
 import { cloneDeep } from "lodash";
 
-import { OrganizerDefaultConferencingAppType, getLocationValueForDB } from "@calcom/app-store/locations";
+import {
+  DefaultFallbackVideoLocationType,
+  OrganizerDefaultConferencingAppType,
+  getLocationValueForDB,
+} from "@calcom/app-store/locations";
 import dayjs from "@calcom/dayjs";
 import {
   sendRoundRobinCancelledEmailsAndSMS as RRCancelledEmailAndSMS,
@@ -66,7 +70,7 @@ class BookingReassignmentManager {
     const bookingSnapshot = await this.fetchBookingData();
     const eventTypeConfig = await this.loadEventTypeConfiguration(bookingSnapshot);
     const enrichedHosts = await this.prepareHostsWithCredentials(eventTypeConfig);
-    
+
     const reassignmentContext = await this.analyzeReassignmentContext(
       bookingSnapshot,
       eventTypeConfig,
@@ -148,7 +152,9 @@ class BookingReassignmentManager {
     return record;
   }
 
-  private async loadEventTypeConfiguration(booking: NonNullable<Awaited<ReturnType<typeof this.fetchBookingData>>>) {
+  private async loadEventTypeConfiguration(
+    booking: NonNullable<Awaited<ReturnType<typeof this.fetchBookingData>>>
+  ) {
     const config = await getEventTypesFromDB(booking.eventTypeId!);
 
     if (!config) {
@@ -156,16 +162,17 @@ class BookingReassignmentManager {
       throw new Error("Event type not found");
     }
 
-    const hostRecords = config.hosts.length > 0
-      ? config.hosts
-      : config.users.map((u) => ({
-          user: u,
-          isFixed: false,
-          priority: 2,
-          weight: 100,
-          schedule: null,
-          createdAt: new Date(0),
-        }));
+    const hostRecords =
+      config.hosts.length > 0
+        ? config.hosts
+        : config.users.map((u) => ({
+            user: u,
+            isFixed: false,
+            priority: 2,
+            weight: 100,
+            schedule: null,
+            createdAt: new Date(0),
+          }));
 
     if (hostRecords.length === 0) {
       throw new Error(ErrorCode.EventTypeNoHosts);
@@ -174,7 +181,9 @@ class BookingReassignmentManager {
     return { ...config, hosts: hostRecords };
   }
 
-  private async prepareHostsWithCredentials(eventTypeConfig: Awaited<ReturnType<typeof this.loadEventTypeConfiguration>>) {
+  private async prepareHostsWithCredentials(
+    eventTypeConfig: Awaited<ReturnType<typeof this.loadEventTypeConfiguration>>
+  ) {
     return enrichHostsWithDelegationCredentials({
       orgId: null,
       hosts: eventTypeConfig.hosts,
@@ -382,7 +391,7 @@ class BookingReassignmentManager {
 
       computedLocation =
         appLink ||
-        getLocationValueForDB(booking.location || "integrations:daily", eventTypeConfig.locations)
+        getLocationValueForDB(booking.location || DefaultFallbackVideoLocationType, eventTypeConfig.locations)
           .bookingLocation;
     }
 
@@ -394,7 +403,7 @@ class BookingReassignmentManager {
       eventName: eventTypeConfig.eventName,
       teamName: teamMembers.length > 1 ? eventTypeConfig.team?.name : null,
       host: organizer.name || "Nameless",
-      location: computedLocation || "integrations:daily",
+      location: computedLocation || DefaultFallbackVideoLocationType,
       bookingFields: { ...bookingData },
       eventDuration,
       t: organizerTranslation,
@@ -405,7 +414,7 @@ class BookingReassignmentManager {
 
   private async swapAttendeeIdentity(booking: any, outgoingHost: any, incomingHost: any) {
     const targetAttendee = booking.attendees.find((a) => a.email === outgoingHost.email);
-    
+
     await prisma.attendee.update({
       where: { id: targetAttendee!.id },
       data: {

--- a/packages/calid/modules/teams/lib/roundRobinReassignment.ts
+++ b/packages/calid/modules/teams/lib/roundRobinReassignment.ts
@@ -1,7 +1,11 @@
 // eslint-disable-next-line no-restricted-imports
 import { cloneDeep } from "lodash";
 
-import { OrganizerDefaultConferencingAppType, getLocationValueForDB } from "@calcom/app-store/locations";
+import {
+  DefaultFallbackVideoLocationType,
+  OrganizerDefaultConferencingAppType,
+  getLocationValueForDB,
+} from "@calcom/app-store/locations";
 import dayjs from "@calcom/dayjs";
 import {
   sendRoundRobinCancelledEmailsAndSMS,
@@ -13,9 +17,6 @@ import { getCalEventResponses } from "@calcom/features/bookings/lib/getCalEventR
 import { ensureAvailableUsers } from "@calcom/features/bookings/lib/handleNewBooking/ensureAvailableUsers";
 import { getEventTypesFromDB } from "@calcom/features/bookings/lib/handleNewBooking/getEventTypesFromDB";
 import type { IsFixedAwareUser } from "@calcom/features/bookings/lib/handleNewBooking/types";
-import AssignmentReasonHandler, {
-  RRReassignmentType,
-} from "./RRAssignmentReasonHandler";
 import {
   enrichHostsWithDelegationCredentials,
   enrichUserWithDelegationCredentialsIncludeServiceAccountKey,
@@ -33,6 +34,7 @@ import { userMetadata as userMetadataSchema } from "@calcom/prisma/zod-utils";
 import type { EventTypeMetadata, PlatformClientParams } from "@calcom/prisma/zod-utils";
 import type { CalendarEvent } from "@calcom/types/Calendar";
 
+import AssignmentReasonHandler, { RRReassignmentType } from "./RRAssignmentReasonHandler";
 import { roundRobinReschedulingManager } from "./handleRescheduleEventManager";
 import { handleWorkflowsUpdate } from "./roundRobinManualReassignment";
 import { bookingSelect } from "./utils/bookingSelect";
@@ -133,12 +135,12 @@ export const roundRobinReassignment = async ({
   const candidateUsers = enrichedEventTypeHosts.reduce((accumulated, hostEntry) => {
     const isCurrentAttendee = bookingAttendeeEmails.has(hostEntry.user.email);
     const isCurrentOrganizer = hostEntry.user.email === initialOrganizer.email;
-    
+
     if (!isCurrentAttendee && !isCurrentOrganizer) {
-      accumulated.push({ 
-        ...hostEntry.user, 
-        isFixed: hostEntry.isFixed, 
-        priority: hostEntry?.priority ?? 2 
+      accumulated.push({
+        ...hostEntry.user,
+        isFixed: hostEntry.isFixed,
+        priority: hostEntry?.priority ?? 2,
       });
     }
     return accumulated;
@@ -223,14 +225,17 @@ export const roundRobinReassignment = async ({
         ? newOrganizerMetaParse?.data?.defaultConferencingApp?.appLink
         : undefined;
 
-      const fallbackBookingLocation = retrievedBooking.location || "integrations:daily";
+      const fallbackBookingLocation = retrievedBooking.location || DefaultFallbackVideoLocationType;
 
       meetingLocation =
         derivedLocationUrl ||
         getLocationValueForDB(fallbackBookingLocation, eventTypeData.locations).bookingLocation;
     }
 
-    const eventDurationInMinutes = dayjs(retrievedBooking.endTime).diff(retrievedBooking.startTime, "minutes");
+    const eventDurationInMinutes = dayjs(retrievedBooking.endTime).diff(
+      retrievedBooking.startTime,
+      "minutes"
+    );
 
     const eventNameParams = {
       attendeeName: parsedResponses?.name || "Nameless",
@@ -238,7 +243,7 @@ export const roundRobinReassignment = async ({
       eventName: eventTypeData.eventName,
       teamName: compiledTeamMembers.length > 1 ? eventTypeData.team?.name : null,
       host: effectiveOrganizer.name || "Nameless",
-      location: meetingLocation || "integrations:daily",
+      location: meetingLocation || DefaultFallbackVideoLocationType,
       bookingFields: { ...parsedResponses },
       eventDuration: eventDurationInMinutes,
       t: effectiveOrganizerTranslation,
@@ -391,7 +396,7 @@ export const roundRobinReassignment = async ({
   if (formerRRHost) {
     const cancellationEventCopy = cloneDeep(enhancedCalendarEvent);
     cancellationEventCopy.title = existingBookingTitle;
-    
+
     if (ownershipChanged) {
       cancellationEventCopy.organizer = {
         name: formerRRHost.name || "",
@@ -437,7 +442,7 @@ export const roundRobinReassignment = async ({
 
   if (ownershipChanged) {
     const eventIsInFuture = dayjs(calendarEventObject.startTime).isAfter(dayjs());
-    
+
     if (emailsEnabled && eventIsInFuture) {
       await sendRoundRobinUpdatedEmailsAndSMS({
         calEvent: eventWithoutCancellation,

--- a/packages/calid/modules/teams/lib/roundRobinReschedulingManager.ts
+++ b/packages/calid/modules/teams/lib/roundRobinReschedulingManager.ts
@@ -7,7 +7,7 @@ import type { EventType } from "@calcom/features/bookings/lib/getAllCredentialsF
 import { getVideoCallDetails } from "@calcom/features/bookings/lib/handleNewBooking/getVideoCallDetails";
 import { getVideoCallUrlFromCalEvent } from "@calcom/lib/CalEventParser";
 import EventManager from "@calcom/lib/EventManager";
-import type { EventManagerUser,  EventManagerInitParams } from "@calcom/lib/EventManager";
+import type { EventManagerUser, EventManagerInitParams } from "@calcom/lib/EventManager";
 import logger from "@calcom/lib/logger";
 import { getTranslation } from "@calcom/lib/server/i18n";
 import { BookingReferenceRepository } from "@calcom/lib/server/repository/bookingReference";
@@ -250,7 +250,14 @@ async function updateBookingRecord(
   logInstance: any
 ) {
   try {
-    const metadataUpdate = videoUrl ? { videoCallUrl: videoUrl } : undefined;
+    const resolvedVideoProvider = calEvent.videoCallData?.type;
+    const metadataUpdate =
+      videoUrl || resolvedVideoProvider
+        ? {
+            ...(videoUrl ? { videoCallUrl: videoUrl } : {}),
+            ...(resolvedVideoProvider ? { videoProvider: resolvedVideoProvider } : {}),
+          }
+        : undefined;
 
     const iCalUIDToStore = eventICalUID !== originalICalUID ? eventICalUID : originalICalUID;
 

--- a/packages/calid/modules/workflows/managers/emailManager.ts
+++ b/packages/calid/modules/workflows/managers/emailManager.ts
@@ -648,7 +648,7 @@ export const scheduleEmailReminder = async (params: EmailNotificationParameters)
 
 export const deleteScheduledEmailReminder = async (
   reminderIdentifier: number,
-  referenceIdentifier: string | null
+  referenceIdentifier?: string | null
 ) => {
   try {
     await prisma.calIdWorkflowReminder.update({

--- a/packages/emails/src/components/LocationInfo.tsx
+++ b/packages/emails/src/components/LocationInfo.tsx
@@ -1,7 +1,7 @@
-import React from "react";
 import type { TFunction } from "i18next";
+import React from "react";
 
-import { guessEventLocationType } from "@calcom/app-store/locations";
+import { getEventLocationTypeFromVideoProvider, guessEventLocationType } from "@calcom/app-store/locations";
 import { getVideoCallUrlFromCalEvent } from "@calcom/lib/CalEventParser";
 import type { CalendarEvent } from "@calcom/types/Calendar";
 
@@ -9,9 +9,15 @@ import { Info } from "./Info";
 
 export function LocationInfo(props: { calEvent: CalendarEvent; t: TFunction }) {
   const { t } = props;
+  const bookingMetadata = (props.calEvent as CalendarEvent & { metadata?: { videoProvider?: string } | null })
+    .metadata;
+  const resolvedVideoProvider =
+    typeof bookingMetadata?.videoProvider === "string" ? bookingMetadata.videoProvider : undefined;
 
   // We would not be able to determine provider name for DefaultEventLocationTypes
-  const providerName = guessEventLocationType(props.calEvent.location)?.label;
+  const providerName =
+    getEventLocationTypeFromVideoProvider(resolvedVideoProvider)?.label ||
+    guessEventLocationType(props.calEvent.location)?.label;
 
   const location = props.calEvent.location;
   let meetingUrl = location?.search(/^https?:/) !== -1 ? location : undefined;

--- a/packages/features/bookings/lib/getAllCredentialsForUsersOnEvent/getAllCredentials.ts
+++ b/packages/features/bookings/lib/getAllCredentialsForUsersOnEvent/getAllCredentials.ts
@@ -10,7 +10,7 @@ import type { CredentialPayload } from "@calcom/types/Credential";
 
 export type EventType = {
   userId?: number | null;
-  team?: { id: number | null; parentId: number | null } | null;
+  calIdTeam?: { id: number | null } | null;
   parentId?: number | null;
   metadata: z.infer<typeof EventTypeMetaDataSchema>;
 } | null;
@@ -26,10 +26,10 @@ export const getAllCredentialsIncludeServiceAccountKey = async (
   let allCredentials = user.credentials;
 
   // If it's a team event type query for team credentials
-  if (eventType?.team?.id) {
+  if (eventType?.calIdTeam?.id) {
     const teamCredentialsQuery = await prisma.credential.findMany({
       where: {
-        teamId: eventType.team.id,
+        calIdTeamId: eventType.calIdTeam.id,
       },
       select: credentialForCalendarServiceSelect,
     });
@@ -38,7 +38,7 @@ export const getAllCredentialsIncludeServiceAccountKey = async (
 
   // If it's a managed event type, query for the parent team's credentials
   if (eventType?.parentId) {
-    const teamCredentialsQuery = await prisma.team.findFirst({
+    const teamCredentialsQuery = await prisma.calIdTeam.findFirst({
       where: {
         eventTypes: {
           some: {

--- a/packages/features/bookings/lib/handleConfirmation.ts
+++ b/packages/features/bookings/lib/handleConfirmation.ts
@@ -248,6 +248,7 @@ export async function handleConfirmation(args: {
 
   const videoCallUrl = metadata.hangoutLink ? metadata.hangoutLink : evt.videoCallData?.url || "";
   const meetingUrl = getVideoCallUrlFromCalEvent(evt) || videoCallUrl;
+  const resolvedVideoProvider = evt.videoCallData?.type;
 
   const updatedBooking = await prisma.booking.update({
     where: {
@@ -259,7 +260,8 @@ export async function handleConfirmation(args: {
       },
       metadata: {
         ...(typeof booking.metadata === "object" ? booking.metadata : {}),
-        videoCallUrl: meetingUrl,
+        ...(meetingUrl ? { videoCallUrl: meetingUrl } : {}),
+        ...(resolvedVideoProvider ? { videoProvider: resolvedVideoProvider } : {}),
       },
     },
     select: {
@@ -331,7 +333,10 @@ export async function handleConfirmation(args: {
       const evtOfBooking = {
         ...evt,
         rescheduleReason: updatedBookings[index].cancellationReason || null,
-        metadata: { videoCallUrl: meetingUrl },
+        metadata: {
+          ...(meetingUrl ? { videoCallUrl: meetingUrl } : {}),
+          ...(resolvedVideoProvider ? { videoProvider: resolvedVideoProvider } : {}),
+        },
         eventType: {
           id: booking.eventTypeId ?? undefined,
           title: eventTypeTitle,
@@ -478,7 +483,13 @@ export async function handleConfirmation(args: {
       eventTypeId: eventType?.id,
       status: "ACCEPTED",
       smsReminderNumber: booking.smsReminderNumber || undefined,
-      metadata: meetingUrl ? { videoCallUrl: meetingUrl } : undefined,
+      metadata:
+        meetingUrl || resolvedVideoProvider
+          ? {
+              ...(meetingUrl ? { videoCallUrl: meetingUrl } : {}),
+              ...(resolvedVideoProvider ? { videoProvider: resolvedVideoProvider } : {}),
+            }
+          : undefined,
       ...(platformClientParams ? platformClientParams : {}),
     };
 

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -2358,11 +2358,18 @@ async function handler(
     videoCallUrl = booking.location;
   }
 
-  const metadata = videoCallUrl
-    ? {
-        videoCallUrl: getVideoCallUrlFromCalEvent(evt) || videoCallUrl,
-      }
-    : undefined;
+  const resolvedVideoProvider = evt.videoCallData?.type;
+  const metadata =
+    videoCallUrl || resolvedVideoProvider
+      ? {
+          ...(videoCallUrl
+            ? {
+                videoCallUrl: getVideoCallUrlFromCalEvent(evt) || videoCallUrl,
+              }
+            : {}),
+          ...(resolvedVideoProvider ? { videoProvider: resolvedVideoProvider } : {}),
+        }
+      : undefined;
 
   const webhookData: EventPayloadType = {
     ...evt,

--- a/packages/lib/EventManager.test.ts
+++ b/packages/lib/EventManager.test.ts
@@ -2,15 +2,24 @@ import type { DestinationCalendar } from "@prisma/client";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 import { symmetricDecrypt } from "@calcom/lib/crypto";
+import type { CalendarEvent } from "@calcom/types/Calendar";
 import type { CredentialForCalendarService } from "@calcom/types/Credential";
 
 import EventManager from "./EventManager";
+import { createMeeting } from "./videoClient";
 
 vi.mock("@calcom/lib/crypto", () => ({
   symmetricDecrypt: vi.fn(),
 }));
 
+vi.mock("./videoClient", () => ({
+  createMeeting: vi.fn(),
+  updateMeeting: vi.fn(),
+  deleteMeeting: vi.fn(),
+}));
+
 const mockedSymmetricDecrypt = vi.mocked(symmetricDecrypt);
+const mockedCreateMeeting = vi.mocked(createMeeting);
 
 function buildCalDAVCredential(data: {
   id: number;
@@ -48,6 +57,47 @@ function buildDestinationCalendar(data: {
     updatedAt: new Date(),
     delegationCredentialId: null,
     domainWideDelegationCredentialId: null,
+  };
+}
+
+function buildVideoCredential(data: {
+  id: number;
+  type: string;
+  appId?: string;
+  userId?: number;
+}): CredentialForCalendarService {
+  return {
+    id: data.id,
+    type: data.type,
+    key: {},
+    userId: data.userId ?? 1,
+    user: { email: "video@example.com" },
+    teamId: null,
+    appId: data.appId ?? "msteams",
+    invalid: false,
+    delegatedTo: null,
+    delegationCredentialId: null,
+  };
+}
+
+function buildVideoEvent(data: { location: string; conferenceCredentialId?: number }): CalendarEvent {
+  return {
+    type: "test-event",
+    title: "Test Event",
+    startTime: new Date().toISOString(),
+    endTime: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
+    organizer: {
+      id: 1,
+      email: "organizer@example.com",
+      name: "Organizer",
+      username: "organizer",
+      language: { locale: "en", translate: ((key: string) => key) as any },
+      timeZone: "UTC",
+      timeFormat: "h:mma",
+    },
+    attendees: [],
+    location: data.location,
+    conferenceCredentialId: data.conferenceCredentialId,
   };
 }
 
@@ -448,5 +498,122 @@ describe("EventManager CalDAV credential validation", () => {
       const result = (eventManager as any).credentialMatchesDestination(credential, destination);
       expect(result).toBe(false);
     });
+  });
+});
+
+describe("EventManager video credential resolution", () => {
+  it("uses exact conferenceCredentialId when it is available", () => {
+    const teamsCredential = buildVideoCredential({ id: 11, type: "office365_video", appId: "msteams" });
+    const eventManager = new EventManager({
+      credentials: [teamsCredential],
+      destinationCalendar: null,
+    });
+    const event = buildVideoEvent({
+      location: "integrations:office365_video",
+      conferenceCredentialId: 11,
+    });
+
+    const resolved = (eventManager as any).getVideoCredential(event);
+    expect(resolved?.id).toBe(11);
+    expect(resolved?.type).toBe("office365_video");
+  });
+
+  it("falls back to provider type when conferenceCredentialId is stale", () => {
+    const teamsCredential = buildVideoCredential({ id: 22, type: "office365_video", appId: "msteams" });
+    const eventManager = new EventManager({
+      credentials: [teamsCredential],
+      destinationCalendar: null,
+    });
+    const event = buildVideoEvent({
+      location: "integrations:office365_video",
+      conferenceCredentialId: 9999,
+    });
+
+    const resolved = (eventManager as any).getVideoCredential(event);
+    expect(resolved?.id).toBe(22);
+    expect(resolved?.type).toBe("office365_video");
+  });
+
+  it("prefers organizer-scoped provider credential when conferenceCredentialId is stale", () => {
+    const otherHostTeamsCredential = buildVideoCredential({
+      id: 40,
+      type: "office365_video",
+      appId: "msteams",
+      userId: 99,
+    });
+    const organizerTeamsCredential = buildVideoCredential({
+      id: 31,
+      type: "office365_video",
+      appId: "msteams",
+      userId: 1,
+    });
+    const eventManager = new EventManager({
+      credentials: [otherHostTeamsCredential, organizerTeamsCredential],
+      destinationCalendar: null,
+    });
+    const event = buildVideoEvent({
+      location: "integrations:office365_video",
+      conferenceCredentialId: 9999,
+    });
+
+    const resolved = (eventManager as any).getVideoCredential(event);
+    expect(resolved?.id).toBe(31);
+    expect(resolved?.userId).toBe(1);
+    expect(resolved?.type).toBe("office365_video");
+  });
+
+  it("falls back to jitsi only when no provider credential is available", () => {
+    const zoomCredential = buildVideoCredential({ id: 33, type: "zoom_video", appId: "zoom" });
+    const eventManager = new EventManager({
+      credentials: [zoomCredential],
+      destinationCalendar: null,
+    });
+    const event = buildVideoEvent({
+      location: "integrations:office365_video",
+      conferenceCredentialId: 9999,
+    });
+
+    const resolved = (eventManager as any).getVideoCredential(event);
+    expect(resolved?.type).toBe("jitsi_video");
+    expect(resolved?.appId).toBe("jitsi");
+    expect(resolved?.id).toBe(0);
+  });
+
+  it("creates a jitsi meeting URL when fallback credential is used", async () => {
+    const zoomCredential = buildVideoCredential({ id: 44, type: "zoom_video", appId: "zoom" });
+    const eventManager = new EventManager({
+      credentials: [zoomCredential],
+      destinationCalendar: null,
+    });
+    const event = buildVideoEvent({
+      location: "integrations:office365_video",
+      conferenceCredentialId: 9999,
+    });
+
+    mockedCreateMeeting.mockResolvedValueOnce({
+      appName: "jitsi",
+      type: "jitsi_video",
+      uid: "fallback-jitsi-meeting",
+      originalEvent: event,
+      success: true,
+      createdEvent: {
+        type: "jitsi_video",
+        id: "fallback-jitsi-room",
+        password: "",
+        url: "https://meet.jit.si/fallback-jitsi-room",
+      },
+      credentialId: 0,
+    } as Awaited<ReturnType<typeof createMeeting>>);
+
+    const result = await (eventManager as any).createVideoEvent(event);
+
+    expect(mockedCreateMeeting).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "jitsi_video",
+        appId: "jitsi",
+      }),
+      event
+    );
+    expect(result?.createdEvent?.url).toContain("meet.jit.si");
   });
 });

--- a/packages/lib/EventManager.ts
+++ b/packages/lib/EventManager.ts
@@ -5,7 +5,7 @@ import { v5 as uuidv5 } from "uuid";
 import type { z } from "zod";
 
 import { getCalendar } from "@calcom/app-store/_utils/getCalendar";
-import { FAKE_DAILY_CREDENTIAL } from "@calcom/app-store/dailyvideo/lib/VideoApiAdapter";
+import { FAKE_JITSI_CREDENTIAL } from "@calcom/app-store/jitsivideo/lib/VideoApiAdapter";
 // import { appKeysSchema as calVideoKeysSchema } from "@calcom/app-store/dailyvideo/zod";
 import { appKeysSchema as JitsiVideoKeysSchema } from "@calcom/app-store/jitsivideo/zod";
 import { getLocationFromApp, JitsiLocationType, MeetLocationType } from "@calcom/app-store/locations";
@@ -1033,29 +1033,125 @@ export default class EventManager {
 
     /** @fixme potential bug since Google Meet are saved as `integrations:google:meet` and there are no `google:meet` type in our DB */
     const integrationName = event.location.replace("integrations:", "");
-    let videoCredential;
+    const organizerId =
+      typeof event.organizer === "object" && "id" in event.organizer ? event.organizer.id ?? null : null;
+    const availableVideoCredentials = this.videoCredentials.map((credential) => ({
+      id: credential.id,
+      type: credential.type,
+      appId: credential.appId ?? null,
+      userId: credential.userId ?? null,
+      teamId: credential.teamId ?? null,
+      delegatedToId: credential.delegatedToId ?? null,
+    }));
+
+    const providerTypeCandidates = this.videoCredentials.filter(
+      (credential: CredentialForCalendarService) =>
+        credential.type === integrationName || credential.type.includes(integrationName)
+    );
+
+    const organizerScopedProviderCandidates =
+      organizerId !== null
+        ? providerTypeCandidates.filter((credential) => credential.userId === organizerId)
+        : [];
+
+    const findByProviderType = () => {
+      if (organizerScopedProviderCandidates.length > 0) {
+        return {
+          credential: organizerScopedProviderCandidates[0],
+          source: "organizer_scoped_type_retry" as const,
+        };
+      }
+      if (providerTypeCandidates.length > 0) {
+        return {
+          credential: providerTypeCandidates[0],
+          source: "generic_type_retry" as const,
+        };
+      }
+      return { credential: undefined, source: null };
+    };
+
+    let selectedCredentialSource:
+      | "exact_id"
+      | "organizer_scoped_type_retry"
+      | "generic_type_retry"
+      | "global_fallback_jitsi"
+      | null = null;
+
+    let videoCredential: CredentialForCalendarService | undefined;
     if (event.conferenceCredentialId) {
       videoCredential = this.videoCredentials.find(
         (credential) => credential.id === event.conferenceCredentialId
       );
+      if (videoCredential) {
+        selectedCredentialSource = "exact_id";
+      }
+      if (!videoCredential) {
+        const providerRetry = findByProviderType();
+        videoCredential = providerRetry.credential;
+        selectedCredentialSource = providerRetry.source;
+        log.warn(
+          "Video credential exact-id lookup failed; attempted provider fallback",
+          safeStringify({
+            fallbackReason: "stale_id",
+            requestedLocation: event.location,
+            requestedIntegration: integrationName,
+            conferenceCredentialId: event.conferenceCredentialId,
+            organizerId,
+            scopedProviderCandidateCredentialIds: organizerScopedProviderCandidates.map(
+              (credential) => credential.id
+            ),
+            genericProviderCandidateCredentialIds: providerTypeCandidates.map((credential) => credential.id),
+            selectedCredentialSource,
+            resolvedCredentialId: videoCredential?.id ?? null,
+            resolvedCredentialType: videoCredential?.type ?? null,
+            availableVideoCredentials,
+          })
+        );
+      }
     } else {
-      videoCredential = this.videoCredentials.find((credential: CredentialForCalendarService) =>
-        credential.type.includes(integrationName)
-      );
+      const providerRetry = findByProviderType();
+      videoCredential = providerRetry.credential;
+      selectedCredentialSource = providerRetry.source;
       log.warn(
-        `Could not find conferenceCredentialId for event with location: ${event.location}, trying to use last added video credential`
+        "No conferenceCredentialId on event; resolving video credential by provider",
+        safeStringify({
+          fallbackReason: "missing_conference_credential_id",
+          requestedLocation: event.location,
+          requestedIntegration: integrationName,
+          conferenceCredentialId: null,
+          organizerId,
+          scopedProviderCandidateCredentialIds: organizerScopedProviderCandidates.map(
+            (credential) => credential.id
+          ),
+          genericProviderCandidateCredentialIds: providerTypeCandidates.map((credential) => credential.id),
+          selectedCredentialSource,
+          resolvedCredentialId: videoCredential?.id ?? null,
+          resolvedCredentialType: videoCredential?.type ?? null,
+          availableVideoCredentials,
+        })
       );
     }
 
     /**
-     * This might happen if someone tries to use a location with a missing credential, so we fallback to Cal Video.
+     * This might happen if someone tries to use a location with a missing credential, so we fallback to Jitsi.
      * @todo remove location from event types that has missing credentials
      * */
     if (!videoCredential) {
+      selectedCredentialSource = "global_fallback_jitsi";
       log.warn(
-        `Falling back to "daily" video integration for event with location: ${event.location} because credential is missing for the app`
+        "Falling back to jitsi video integration because no provider credential could be resolved",
+        safeStringify({
+          fallbackReason: "missing_provider_credential",
+          fallbackProvider: "jitsi_video",
+          selectedCredentialSource,
+          requestedLocation: event.location,
+          requestedIntegration: integrationName,
+          conferenceCredentialId: event.conferenceCredentialId ?? null,
+          organizerId,
+          availableVideoCredentials,
+        })
       );
-      videoCredential = { ...FAKE_DAILY_CREDENTIAL };
+      videoCredential = { ...FAKE_JITSI_CREDENTIAL };
     }
 
     return videoCredential;

--- a/packages/lib/videoClient.ts
+++ b/packages/lib/videoClient.ts
@@ -21,6 +21,33 @@ const log = logger.getSubLogger({ prefix: ["[lib] videoClient"] });
 
 const translator = short();
 
+const getVideoFallbackReason = (error: unknown): "missing_install" | "missing_scope" | "provider_error" => {
+  const message =
+    typeof error === "string"
+      ? error
+      : error instanceof Error
+      ? error.message
+      : safeStringify(error).toLowerCase();
+  const normalizedMessage = message.toLowerCase();
+
+  if (normalizedMessage.includes("disabled or not seeded")) {
+    return "missing_install";
+  }
+
+  if (
+    normalizedMessage.includes("scope") ||
+    normalizedMessage.includes("permission") ||
+    normalizedMessage.includes("insufficient") ||
+    normalizedMessage.includes("forbidden") ||
+    normalizedMessage.includes("unauthorized") ||
+    normalizedMessage.includes("invalid_grant")
+  ) {
+    return "missing_scope";
+  }
+
+  return "provider_error";
+};
+
 // factory
 const getVideoAdapters = async (withCredentials: CredentialPayload[]): Promise<VideoApiAdapter[]> => {
   const videoAdapters: VideoApiAdapter[] = [];
@@ -112,14 +139,23 @@ const createMeeting = async (credential: CredentialPayload, calEvent: CalendarEv
     log.debug("created Meeting", safeStringify(returnObject));
   } catch (err) {
     await sendBrokenIntegrationEmail(calEvent, "video");
+    const fallbackReason = getVideoFallbackReason(err);
     log.error(
       "createMeeting failed",
       safeStringify(err),
-      safeStringify({ calEvent: getPiiFreeCalendarEvent(calEvent) })
+      safeStringify({
+        fallbackReason,
+        credential: getPiiFreeCredential(credential),
+        calEvent: getPiiFreeCalendarEvent(calEvent),
+      })
     );
 
     // Fallback to Jitsi
     // Note: Jitsi creates permanent rooms, so recurring events work automatically
+    log.warn(
+      "Falling back to jitsi video meeting creation",
+      safeStringify({ fallbackReason, fallbackProvider: "jitsi_video" })
+    );
     const defaultMeeting = await createMeetingWithJitsiVideo(calEvent);
     if (defaultMeeting) {
       calEvent.location = JitsiLocationType;
@@ -216,7 +252,7 @@ const deleteMeeting = async (credential: CredentialPayload | null, uid: string):
   return Promise.resolve({});
 };
 
-// @TODO: This is a temporary solution to create a meeting with cal.com video as fallback url
+// @TODO: This is a temporary solution to create a Cal Video meeting room directly.
 const createMeetingWithCalVideo = async (calEvent: CalendarEvent) => {
   let dailyAppKeys: Awaited<ReturnType<typeof getDailyAppKeys>>;
   try {

--- a/packages/prisma/zod-utils.ts
+++ b/packages/prisma/zod-utils.ts
@@ -480,6 +480,7 @@ export const recurringEventSchema = z.object({
 export const bookingMetadataSchema = z
   .object({
     videoCallUrl: z.string().optional(),
+    videoProvider: z.string().optional(),
     meetingNote: z.string().optional(),
     recurringEvent: recurringEventSchema.optional(),
   })


### PR DESCRIPTION
## Problem

Bookings could show a provider label (e.g. Teams) that didn’t match the actual join URL when:
1. `conferenceCredentialId` became stale (credential rotation/reconnect), and
2. runtime resolution fell back too early / inconsistently.

Also, implicit fallback behavior was still partly Daily-based in some flows, while we now want Jitsi as the default fallback.

## What changed

### 1) Provider resolution correctness
- Updated `EventManager.getVideoCredential()` resolution order to:
  1. exact `conferenceCredentialId`
  2. organizer-scoped provider-type retry
  3. generic provider-type retry
  4. global Jitsi fallback
- Added detailed structured logs for stale-id and fallback decisions, including selected source and candidate IDs.

### 2) Default fallback provider switched to Jitsi
- Replaced implicit fake fallback credential usage from Daily to Jitsi.
- Added `FAKE_JITSI_CREDENTIAL`.
- Kept explicit Daily configuration behavior unchanged.
- `videoClient` fallback logging now clearly reports Jitsi fallback context.

### 3) Booking metadata consistency
- Persist actual resolved provider to `metadata.videoProvider` alongside `metadata.videoCallUrl`.
- Applied in create, confirmation, and round-robin reschedule update paths.
- Updated `bookingMetadataSchema` to include `videoProvider`.

### 4) UI/email label consistency
- Rendering now prefers `metadata.videoProvider` (when present) for provider label instead of relying only on raw `booking.location`.
- Updated:
  - bookings single view
  - booking list item
  - meetings card
  - email location info

### 5) Shared fallback source of truth for reassignment
- Added shared constant:
  - `DefaultFallbackVideoLocationType = JitsiLocationType`
- Replaced remaining hardcoded `integrations:daily` defaults in round-robin reassignment flows to use the shared constant.

### 6) API metadata hygiene
- `videoCallUrl` / `videoProvider` are excluded from user-defined metadata in v2 output service.

## Why this is safe

- Exact-id behavior remains unchanged when valid.
- Organizer-aware retry only applies when exact-id is stale/missing and organizer identity is available.
- Generic retry path remains for cases without organizer identity.
- Explicit Daily usage remains supported; only implicit default fallback changed.
