### PR TITLE
fix(sms-on-cancellation):added missing bookingFields to calEvent obje…

### DIFF
--- a/packages/features/bookings/lib/handleCancelBooking.ts
+++ b/packages/features/bookings/lib/handleCancelBooking.ts
@@ -424,6 +424,7 @@ async function handler(input: CancelBookingInput) {
     seatsShowAttendees: !!bookingToDelete.eventType?.seatsShowAttendees,
     seatsPerTimeSlot: bookingToDelete.eventType?.seatsPerTimeSlot,
     recurringEvent: parseRecurringEvent(bookingToDelete.eventType?.recurringEvent),
+    bookingFields: bookingToDelete.eventType?.bookingFields ?? [],
     ...(teamMembers &&
       teamId && {
         team: {


### PR DESCRIPTION
Fixed cancellation sms being sent for cancelled bookings even for eventTypes with email field 
closes #997 