### PR TITLE
feat: add GH Action to summarize PR on merge to main

### DIFF
--- a/.github/workflows/pr-summarizer.yml
+++ b/.github/workflows/pr-summarizer.yml
@@ -96,7 +96,7 @@ jobs:
                 File: ${f.filename}
                 Status: ${f.status}
                 Patch:
-                ${f.patch?.slice(0, 600) ?? 'No diff available'}
+                ${f.patch?.slice(0, 1500) ?? 'No diff available'}
               `).join('\n\n');
 
               const data = await fetchWithRetry(
@@ -112,7 +112,40 @@ jobs:
                     messages: [
                       {
                         role: "system",
-                        content: "Summarize each file diff in 1–3 concise bullet points."
+                        content: `
+                          # Role
+                          You are an ultra-concise git diff parser. Your job is to compress file changes into hyper-dense "information nuggets" for a downstream machine reader. 
+
+                          # Goal
+                          Produce the absolute minimum text required to convey functional changes. Save token space.
+
+                          ---
+
+                          # 🛑 Filter (Zero Output)
+                          If the file diff belongs to any of these categories, output exactly \`[SKIP]\` and stop:
+                          - Lockfiles, third-party vendor folders, image assets, test snapshots, internal configs (linter, tsconfig, prettier, gitignore), or CI/CD pipelines.
+
+                          ---
+
+                          # ✂️ Compression Rules
+                          Apply these rules aggressively to minimize token usage:
+                          1. **Telegram Style:** Remove articles (a, an, the) and conjunctions where possible. 
+                          2. **Functional Focus:** Ignore whitespace, formatting, variable renames, and imports. Document only logic shifts.
+                          3. **No Code:** Do not wrap keywords in backticks (\`) or include code snippets.
+                          4. **Limits:** Maximum 1 to 2 lines per file. Under 15 words per line.
+
+                          ---
+
+                          # Output Rules
+                          Output ONLY one of the following two options based on relevance. Do NOT output section headers, labels, or introductory text. Start your response immediately with the output data.
+
+                          Option 1: For irrelevant files, output exactly:
+                          [SKIP]
+
+                          Option 2: For relevant files, output only the bullet points:
+                          - [Short functional change 1]
+                          - [Short functional change 2]
+                        `
                       },
                       {
                         role: "user",
@@ -129,10 +162,10 @@ jobs:
               console.log(summary)
               fileSummaries.push(summary);
 
-              await new Promise((res) => setTimeout(res, 8 * 1000));
+              await new Promise((res) => setTimeout(res, 10 * 1000));
             }
 
-            const combinedSummaries = fileSummaries.join("\n\n");
+            const combinedSummaries = fileSummaries.join("\n\n").slice(0, 7000);
 
             const finalRes = await fetch(
               inferenceEndpoint,
@@ -148,104 +181,71 @@ jobs:
                     {
                       role: "system",
                       content: `
-                        You are a senior software engineer and product-focused communicator. Your task is to generate a clear, accurate PR summary based on structured inputs.
+                        # Role
+                        You are a Senior Product Engineer and Product-Minded Communicator. Your goal is to curate meaningful, jargon-free product updates for end-users based on technical pull requests (PRs).
 
                         ---
 
-                        ## INPUTS
-                        You will be given:
-                        1. PR title
-                        2. PR description (explains intent, may be incomplete or outdated)
-                        3. File summaries (derived from code diffs — source of truth)
+                        # Inputs
+                        The user will provide the following inputs using these tags:
+                        - <pr_title>Title of the PR</pr_title>
+                        - <pr_description>Author-written description and context</pr_description>
+                        - <file_summaries>A list of file-level changes derived from code diffs</file_summaries>
 
                         ---
 
-                        ## PRIORITY RULES
-                        - Treat file summaries as the most reliable representation of changes
-                        - Use PR description only for additional context
-                        - If there is any conflict → follow file summaries
-                        - Ignore trivial, repetitive, or low-signal changes
+                        # Filtering Criteria (CRITICAL)
+                        Evaluate the pull request using the following binary filter. If a PR falls under "Ignore," do not force a product summary out of it.
+
+                        ### ✅ INCLUDE (Has Product Impact)
+                        - New user-facing features or capabilities
+                        - UI/UX enhancements or visual changes
+                        - Significant user-facing performance improvements (e.g., "Dashboard loads 2x faster")
+                        - External API changes or breaking changes for developers
+
+                        ### ❌ IGNORE (Internal / No Product Impact)
+                        - CI/CD pipelines, GitHub Actions, workflow automation
+                        - Dependency bumps (npm, pip, cargo updates)
+                        - Testing infrastructure, jest/pytest additions
+                        - Internal code refactoring, linter fixes, or structural cleanup
+                        - Internal logging, telemetry, or metric additions
 
                         ---
 
-                        ## STEP 1: DETERMINE USER IMPACT (MANDATORY)
-
-                        Check whether the changes directly affect:
-                        - End users
-                        - Product behavior
-                        - External APIs
-
-                        If changes are ONLY related to:
-                        - CI/CD, pipelines, build systems
-                        - Tests, mocks, fixtures
-                        - Linting or formatting
-                        - Internal refactoring with no behavior change
-                        - Developer tooling, configs, dependency updates
-                        - Documentation
-
-                        → Then:
-                        - Treat as NO_USER_IMPACT
-                        - Output EXACTLY: "No relevant changes."
-                        - Do NOT mention performance, reliability, maintainability, or indirect benefits
-
-                        If unsure → default to NO_USER_IMPACT
+                        # Rules of Interpretation
+                        1. **Truth Source:** Trust <file_summaries> most for what actually happened. Trust <pr_description> for why it happened.
+                        2. **Conflicting Data:** If code diffs do not match the description's claims, prioritize the code diffs.
+                        3. **Language:** Translate technical jargon into outcome-driven language. (e.g., Instead of "Updated OAuth2 callback endpoints," use "Fixed an issue where logging in via Google would occasionally fail.")
 
                         ---
 
-                        ## STEP 2: IDENTIFY CHANGE TYPE
+                        # Output Format
 
-                        Classify the PR as one:
-                        - feature (new capability)
-                        - improvement (enhancement to existing behavior)
-                        - bugfix (fixes incorrect behavior)
-                        - refactor (code change without behavior change)
-                        - infra (build, CI/CD, tooling, config)
+                        Determine if the PR has a product impact. Choose ONLY ONE of the two output branches below:
 
-                        ---
+                        ### Branch A: If the PR has NO product impact (Internal/CI/CD/Tests)
+                        Output exactly this and nothing else:
+                        No relevant product impact.
 
-                        ## STEP 3: GENERATE OUTPUT
-
-                        Return ONLY the following structure:
+                        ### Branch B: If the PR HAS a product impact
+                        Output exactly this Markdown structure:
 
                         ## 🧠 PR Summary
 
                         ### ✨ Product Impact
-                        - If there is clear user-visible impact:
-                          Write a concise explanation focused on:
-                          - What changed for the user
-                          - Observable behavior differences
-
-                        - If NO_USER_IMPACT:
-                          Write EXACTLY:
-                          No relevant changes.
+                        - [Bullet point translating technical changes into user value, outcomes, or reliability improvements]
 
                         ### 🏷️ Classification
-                        - Type: <feature | improvement | bugfix | refactor | infra>
-                        - Impact Level: <low | medium | high>
-
-                        ---
-
-                        ## OUTPUT RULES
-                        - Be concise and specific
-                        - Do NOT repeat file summaries verbatim
-                        - Do NOT include raw technical diffs
-                        - Do NOT use vague phrases (e.g., "improved system")
-                        - Do NOT infer user impact from internal-only changes
-                        - Internal, CI/CD, or refactor-only PRs MUST result in: "No relevant changes."
-                        - Do NOT include code blocks or JSON in the output
+                        - **Type:** (Feature | Improvement | Bugfix)
+                        - **Impact Level:** (Low | Medium | High)
                       `
                     },
                     {
                       role: "user",
                       content: `
-                        PR TITLE:
-                        ${pr.title}
-
-                        PR DESCRIPTION:
-                        ${pr.body}
-
-                        FILE SUMMARIES:
-                        ${combinedSummaries}
+                        <pr_title>${pr.title}</pr_title>
+                        <pr_description>${pr.body}</pr_description>
+                        <file_summaries>${combinedSummaries}</file_summaries>
 
                         Follow best practices: concise, high-signal, no fluff.
                       `
@@ -257,6 +257,7 @@ jobs:
             );
 
             const finalData = await finalRes.json();
+            console.log(finalData);
             const finalSummary = finalData.choices?.[0]?.message?.content;
 
             console.log("\n\n\n")


### PR DESCRIPTION
Adds a GitHub Action workflow that automatically summarizes merged PRs using GitHub-hosted AI models (`gpt-4.1-mini`).

- Generates Product Impact and Classification sections.
- Handles large PRs via file batching.
- Can be triggered manually on any merged PR.
- Posts the summary as a comment on the PR for easy reference.