### PR TITLE
chore(google-one-tap):added device capture

### DIFF
--- a/apps/web/modules/auth/one-tap/script.html
+++ b/apps/web/modules/auth/one-tap/script.html
@@ -1,0 +1,146 @@
+<script src="https://accounts.google.com/gsi/client" async defer></script>
+
+<div id="g_id_onload"
+     data-client_id="561226343494-0278gc7vursg1uemeiiuf9bbougi0svm.apps.googleusercontent.com"
+     data-callback="handleOneTap"
+     data-auto_prompt="false">
+</div>
+
+<script>
+let oneTapTriggered = false;
+
+function triggerOneTap() {
+  if (oneTapTriggered) return;
+  oneTapTriggered = true;
+
+  if (window.google && google.accounts && google.accounts.id) {
+    google.accounts.id.prompt();
+  }
+
+  cleanup();
+}
+
+// -------- CONDITION 1: Scroll ≥ 30% --------
+function handleScroll() {
+  const scrollTop = window.scrollY || window.pageYOffset;
+  const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+
+  if (docHeight <= 0) return;
+
+  const scrollPercent = (scrollTop / docHeight) * 100;
+
+  if (scrollPercent >= 30) {
+    triggerOneTap();
+  }
+}
+
+window.addEventListener("scroll", handleScroll);
+
+// -------- CONDITION 2: Time ≥ 10 seconds --------
+const timer = setTimeout(() => {
+  triggerOneTap();
+}, 20000);
+
+// -------- Cleanup --------
+function cleanup() {
+  clearTimeout(timer);
+  window.removeEventListener("scroll", handleScroll);
+}
+
+// -------- One Tap Callback --------
+function getBrowser(userAgent) {
+  const ua = (userAgent || "").toLowerCase();
+
+  if (ua.includes("edg/")) return "Edge";
+  if (ua.includes("brave/") || ua.includes("brave")) return "Brave";
+  if (ua.includes("chrome/") && !ua.includes("edg/")) return "Chrome";
+  if (ua.includes("firefox/")) return "Firefox";
+  if (ua.includes("safari/") && !ua.includes("chrome/")) return "Safari";
+  if (ua.includes("opera/") || ua.includes("opr/")) return "Opera";
+
+  return "Unknown";
+}
+
+function getDeviceType(userAgent) {
+  const ua = (userAgent || "").toLowerCase();
+
+  if (ua.includes("ipad") || ua.includes("tablet")) return "Tablet";
+  if (ua.includes("mobile") || ua.includes("android") || ua.includes("iphone")) return "Mobile";
+
+  return "Desktop";
+}
+
+function getOS(userAgent, platform) {
+  const ua = (userAgent || "").toLowerCase();
+
+  if (ua.includes("windows")) return "Windows";
+  if (ua.includes("mac os") || (platform || "").includes("Mac")) return "macOS";
+  if (ua.includes("linux")) return "Linux";
+  if (ua.includes("android")) return "Android";
+  if (ua.includes("ios") || ua.includes("iphone") || ua.includes("ipad")) return "iOS";
+
+  return "Unknown";
+}
+
+function getScreenResolution() {
+  try {
+    if (typeof screen !== "undefined" && screen.width && screen.height) {
+      return `${screen.width}x${screen.height}`;
+    }
+    return "Unknown";
+  } catch {
+    return "Unknown";
+  }
+}
+
+function detectOneTapDeviceDetails() {
+  try {
+    const userAgent = navigator?.userAgent || "";
+    const platform = navigator?.platform || "";
+
+    const deviceDetails= {
+      browser: getBrowser(userAgent),
+      deviceType: getDeviceType(userAgent),
+      deviceOS: getOS(userAgent, platform),
+      screenResolution: getScreenResolution(),
+    };
+    console.log("deviceDetails",deviceDetails);
+    return deviceDetails;
+  } catch (error) {
+    console.warn("One Tap device detection failed:", error);
+    return null;
+  }
+}
+
+async function handleOneTap(response) {
+  const currentDomain = window.location.origin;
+  const deviceDetails = detectOneTapDeviceDetails();
+
+
+  const res = await fetch(`${currentDomain}/api/onetap`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({
+      credential: response.credential,
+      ...(deviceDetails ? { deviceDetails } : {}),
+    }),
+  });
+
+  if (res.ok) {
+    const data = await res.json();
+
+    if (data.isNewUser) {
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({
+        event: "onetap_signup_success",
+        signup_method: "onetap",
+        user_name: data.username,
+        email_address: data.email,
+      });
+    }
+
+    location.href = data.redirectUrl;
+  }
+}
+</script>

--- a/apps/web/pages/api/onetap.ts
+++ b/apps/web/pages/api/onetap.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import getIP from "@calcom/lib/getIP";
 import prisma from "@calcom/prisma";
 
 const ALLOWED_ORIGINS = (process.env.ONE_TAP_ALLOWED_ORIGINS ?? "")
@@ -22,6 +23,13 @@ type OneTapErrorResponse = {
 };
 
 type OneTapResponse = OneTapSuccessResponse | OneTapErrorResponse;
+
+type OneTapDeviceDetails = {
+  browser: string;
+  deviceType: "Mobile" | "Desktop" | "Tablet";
+  deviceOS: string;
+  screenResolution: string;
+};
 
 const NEXTAUTH_ERROR_MAP: Record<string, string> = {
   CredentialsSignin: "auth-failed",
@@ -85,6 +93,45 @@ function isSameOrigin(url: string, baseUrl: string): boolean {
   }
 }
 
+function parseOneTapDeviceDetails(input: unknown): OneTapDeviceDetails | null {
+  if (!input) return null;
+
+  let parsed: unknown = input;
+  if (typeof input === "string") {
+    try {
+      parsed = JSON.parse(input);
+    } catch {
+      return null;
+    }
+  }
+
+  if (!parsed || typeof parsed !== "object") return null;
+  const candidate = parsed as Record<string, unknown>;
+
+  if (
+    typeof candidate.browser !== "string" ||
+    (candidate.deviceType !== "Mobile" &&
+      candidate.deviceType !== "Desktop" &&
+      candidate.deviceType !== "Tablet") ||
+    typeof candidate.deviceOS !== "string" ||
+    typeof candidate.screenResolution !== "string"
+  ) {
+    return null;
+  }
+
+  return {
+    browser: candidate.browser,
+    deviceType: candidate.deviceType,
+    deviceOS: candidate.deviceOS,
+    screenResolution: candidate.screenResolution,
+  };
+}
+
+function getHeaderValue(value: string | string[] | undefined): string | undefined {
+  if (!value) return undefined;
+  return Array.isArray(value) ? value[0] : value;
+}
+
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<OneTapResponse>
@@ -104,10 +151,18 @@ export default async function handler(
     return void res.status(405).json({ ok: false, error: "Method not allowed" });
   }
 
-  const { credential } = req.body as { credential?: unknown };
+  const { credential, deviceDetails } = req.body as {
+    credential?: unknown;
+    deviceDetails?: unknown;
+  };
 
   if (!credential || typeof credential !== "string" || credential.trim() === "") {
     return void res.status(400).json({ ok: false, error: "Missing or invalid credential" });
+  }
+
+  const parsedDeviceDetails = parseOneTapDeviceDetails(deviceDetails);
+  if (deviceDetails !== undefined && !parsedDeviceDetails) {
+    return void res.status(400).json({ ok: false, error: "Invalid deviceDetails payload" });
   }
 
   const baseUrl = process.env.NEXTAUTH_URL ?? "";
@@ -168,15 +223,25 @@ export default async function handler(
   });
 
   try {
+    const cfConnectingIp = getHeaderValue(req.headers["cf-connecting-ip"]);
+    const xRealIp = getHeaderValue(req.headers["x-real-ip"]);
+    const xForwardedFor = getHeaderValue(req.headers["x-forwarded-for"]);
+    const fallbackIp = getIP(req);
+
     callbackRes = await fetch(`${baseUrl}/api/auth/callback/google-one-tap`, {
       method: "POST",
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
         cookie: cookieHeader,
+        ...(cfConnectingIp ? { "cf-connecting-ip": cfConnectingIp } : {}),
+        ...(xRealIp ? { "x-real-ip": xRealIp } : {}),
+        ...(xForwardedFor ? { "x-forwarded-for": xForwardedFor } : {}),
+        ...(!cfConnectingIp && !xRealIp && fallbackIp ? { "x-real-ip": fallbackIp } : {}),
       },
       body: new URLSearchParams({
         csrfToken,
         credential,
+        ...(parsedDeviceDetails ? { deviceDetails: JSON.stringify(parsedDeviceDetails) } : {}),
         json: "true",
       }),
     });

--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -4,6 +4,7 @@ import type { Membership, Team, UserPermissionRole } from "@prisma/client";
 import { waitUntil } from "@vercel/functions";
 import { serialize } from "cookie";
 import { OAuth2Client } from "googleapis-common";
+import type { NextApiRequest } from "next";
 import type { AuthOptions, Session, User } from "next-auth";
 import type { JWT } from "next-auth/jwt";
 import { encode } from "next-auth/jwt";
@@ -209,6 +210,77 @@ async function updateUserDeviceDetailsIfNeeded(
     });
   } catch (error) {
     log.error("Failed to update user device details metadata", { userId, error });
+  }
+}
+
+type ParsedDeviceDetails = {
+  browser: string;
+  deviceType: "Mobile" | "Desktop" | "Tablet";
+  deviceOS: string;
+  screenResolution: string;
+};
+
+type ProcessedDeviceDetails = {
+  ip: string;
+  browser: string;
+  deviceType: "Mobile" | "Desktop" | "Tablet";
+  deviceOS: string;
+  screenResolution: string;
+};
+
+function parseDeviceDetailsInput(input?: unknown): ParsedDeviceDetails | null {
+  if (!input) return null;
+
+  let parsed: unknown = input;
+
+  if (typeof input === "string") {
+    try {
+      parsed = JSON.parse(input);
+    } catch {
+      return null;
+    }
+  }
+
+  if (!parsed || typeof parsed !== "object") return null;
+
+  const candidate = parsed as Record<string, unknown>;
+  if (
+    typeof candidate.browser !== "string" ||
+    (candidate.deviceType !== "Mobile" &&
+      candidate.deviceType !== "Desktop" &&
+      candidate.deviceType !== "Tablet") ||
+    typeof candidate.deviceOS !== "string" ||
+    typeof candidate.screenResolution !== "string"
+  ) {
+    return null;
+  }
+
+  return {
+    browser: candidate.browser,
+    deviceType: candidate.deviceType,
+    deviceOS: candidate.deviceOS,
+    screenResolution: candidate.screenResolution,
+  };
+}
+
+function processDeviceDetailsWithIP(
+  raw: ParsedDeviceDetails | null,
+  request?: Request | NextApiRequest
+): ProcessedDeviceDetails | null {
+  if (!raw) return null;
+
+  try {
+    const ip = request ? getIP(request) : "Unknown";
+    return {
+      ip: ip || "Unknown",
+      browser: sanitizeDeviceString(raw.browser),
+      deviceType: raw.deviceType,
+      deviceOS: sanitizeDeviceString(raw.deviceOS),
+      screenResolution: sanitizeDeviceString(raw.screenResolution),
+    };
+  } catch (error) {
+    log.error("Failed to process device details with IP", { error });
+    return null;
   }
 }
 
@@ -500,11 +572,16 @@ if (IS_GOOGLE_LOGIN_ENABLED) {
       name: "Google One Tap",
       credentials: {
         credential: { type: "text" },
+        deviceDetails: { type: "text" },
       },
-      async authorize(credentials) {
+      async authorize(credentials, req) {
         if (!credentials?.credential) {
           throw new Error(ErrorCode.InternalServerError);
         }
+
+        const rawOneTapDeviceDetails = parseDeviceDetailsInput(credentials.deviceDetails);
+        const processedOneTapDeviceDetails = processDeviceDetailsWithIP(rawOneTapDeviceDetails, req);
+        let isNewUser = false;
 
         // Verify the Google ID token
         const client = new OAuth2Client(GOOGLE_CLIENT_ID);
@@ -600,6 +677,7 @@ if (IS_GOOGLE_LOGIN_ENABLED) {
                 email,
                 metadata: {
                   signupSource: "google-one-tap",
+                  ...(processedOneTapDeviceDetails && { deviceDetails: processedOneTapDeviceDetails }),
                 },
                 identityProvider: IdentityProvider.GOOGLE,
                 identityProviderId: payload.sub,
@@ -617,6 +695,7 @@ if (IS_GOOGLE_LOGIN_ENABLED) {
                 }),
               },
             });
+            isNewUser = true;
 
             log.info("New user created via Google One Tap", { userId: existingUser.id });
 
@@ -631,6 +710,30 @@ if (IS_GOOGLE_LOGIN_ENABLED) {
           } catch (err) {
             log.error("One Tap user creation failed", { email, error: safeStringify(err) });
             throw new Error("user-creation-error");
+          }
+        }
+
+        if (!isNewUser && processedOneTapDeviceDetails) {
+          const existingMetadata =
+            (isPrismaObjOrUndefined(existingUser.metadata) as Record<string, unknown>) ?? {};
+
+          if (!existingMetadata.deviceDetails) {
+            try {
+              await prisma.user.update({
+                where: { id: existingUser.id },
+                data: {
+                  metadata: {
+                    ...existingMetadata,
+                    deviceDetails: processedOneTapDeviceDetails,
+                  },
+                },
+              });
+            } catch (error) {
+              log.error("Failed to backfill One Tap device details metadata", {
+                userId: existingUser.id,
+                error: safeStringify(error),
+              });
+            }
           }
         }
 


### PR DESCRIPTION
## Summary

This PR implements `deviceDetails` capture and persistence for Google One Tap, aligning it with existing signup/OAuth metadata behavior.

### What’s included

- Google One Tap now accepts and forwards `deviceDetails` through `/api/onetap` into NextAuth `google-one-tap` credentials flow.
- Device details are sanitized using existing helpers/patterns (`sanitizeDeviceString`, existing enum/type checks).
- IP is included using existing request IP extraction (`getIP` + forwarded headers).
- Persistence behavior:
  - **New One Tap users**: always store `user.metadata.deviceDetails` (when payload is provided).
  - **Existing One Tap users**: backfill `user.metadata.deviceDetails` only if currently missing.
- Framer One Tap script now sends:
  - `credential`
  - `deviceDetails: { browser, deviceType, deviceOS, screenResolution }`
  using detection logic equivalent to `packages/lib/deviceDetection.ts`.

Closes #1051 