### PR TITLE
chore(workflow-status):improved workflow status casing

### DIFF
--- a/apps/web/components/dialog/WorkflowStatusDialog.tsx
+++ b/apps/web/components/dialog/WorkflowStatusDialog.tsx
@@ -233,8 +233,6 @@ export const WorkflowStatusDialog = ({
     </div>
   );
 
-  console.log("Details: ", workflowInsights);
-
   return (
     <Dialog open={isOpenDialog} onOpenChange={handleDialogChange}>
       <DialogContent enableOverflow showCloseButton={true}>


### PR DESCRIPTION
For default status the status was being rendered as all Capital while other mapped cases appeared titlecased.