### PR TITLE
fix(bookings): make Google Meet URL propagation deterministic and res…

### DIFF
--- a/apps/web/modules/bookings/views/bookings-single-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-single-view.tsx
@@ -1,5 +1,10 @@
 "use client";
 
+import {
+  useEmbedNonStylesConfig,
+  useIsBackgroundTransparent,
+  useIsEmbed,
+} from "@calid/embed-runtime/embed-iframe";
 import { generateRecurringInstances } from "@calid/features/modules/teams/lib/recurrenceUtil";
 import { Alert } from "@calid/features/ui/components/alert";
 import { Badge } from "@calid/features/ui/components/badge";
@@ -26,11 +31,6 @@ import {
 } from "@calcom/app-store/locations";
 import { getEventTypeAppData } from "@calcom/app-store/utils";
 import dayjs from "@calcom/dayjs";
-import {
-  useEmbedNonStylesConfig,
-  useIsBackgroundTransparent,
-  useIsEmbed,
-} from "@calid/embed-runtime/embed-iframe";
 import { Price } from "@calcom/features/bookings/components/event-meta/Price";
 import { SystemField, TITLE_FIELD } from "@calcom/features/bookings/lib/SystemField";
 import { getCalendarLinks, CalendarLinkType } from "@calcom/lib/bookings/getCalendarLinks";
@@ -97,6 +97,23 @@ const useBrandColors = ({
     darkVal: darkBrandColor,
   });
   useCalcomTheme(brandTheme);
+};
+
+const inferProviderNameFromMeetingUrl = (meetingUrl?: string) => {
+  if (!meetingUrl) {
+    return undefined;
+  }
+
+  const normalizedUrl = meetingUrl.toLowerCase();
+  if (
+    normalizedUrl.includes("meet.google.com") ||
+    normalizedUrl.includes("g.co/meet") ||
+    normalizedUrl.includes("google.com/meet")
+  ) {
+    return getEventLocationTypeFromVideoProvider("google_meet_video")?.label || "Google Meet";
+  }
+
+  return undefined;
 };
 
 export default function Success(props: PageProps) {
@@ -364,8 +381,12 @@ export default function Success(props: PageProps) {
 
   const providerName =
     getEventLocationTypeFromVideoProvider(resolvedVideoProvider)?.label ||
-    guessEventLocationType(location)?.label;
-  const rescheduleProviderName = guessEventLocationType(rescheduleLocation)?.label;
+    guessEventLocationType(location)?.label ||
+    inferProviderNameFromMeetingUrl(locationToDisplay) ||
+    inferProviderNameFromMeetingUrl(locationVideoCallUrl || location);
+  const rescheduleProviderName =
+    guessEventLocationType(rescheduleLocation)?.label ||
+    inferProviderNameFromMeetingUrl(rescheduleLocationToDisplay);
   const isBookingInPast = new Date(bookingInfo.endTime) < new Date();
   const isReschedulable = !isCancelled;
 

--- a/packages/app-store/googlecalendar/lib/CalendarService.ts
+++ b/packages/app-store/googlecalendar/lib/CalendarService.ts
@@ -38,6 +38,7 @@ interface GoogleCalError extends Error {
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const ONE_MONTH_IN_MS = 30 * MS_PER_DAY;
+const GOOGLE_MEET_URL_RETRY_DELAYS_MS = [250, 500, 1000] as const;
 // eslint-disable-next-line turbo/no-undeclared-env-vars -- GOOGLE_WEBHOOK_URL only for local testing
 const GOOGLE_WEBHOOK_URL_BASE = process.env.GOOGLE_WEBHOOK_URL || process.env.NEXT_PUBLIC_WEBAPP_URL;
 const GOOGLE_WEBHOOK_URL = `${GOOGLE_WEBHOOK_URL_BASE}/api/integrations/googlecalendar/webhook`;
@@ -73,6 +74,61 @@ export default class GoogleCalendarService implements Calendar {
   public async authedCalendar(): Promise<calendar_v3.Calendar> {
     this.log.debug("Getting authed calendar");
     return this.auth.getClient();
+  }
+
+  private async delay(ms: number) {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private extractMeetingUrl(event?: calendar_v3.Schema$Event | null): string | undefined {
+    if (!event) {
+      return undefined;
+    }
+
+    if (typeof event.hangoutLink === "string" && event.hangoutLink.length > 0) {
+      return event.hangoutLink;
+    }
+
+    const entryPoints = event.conferenceData?.entryPoints;
+    if (!entryPoints?.length) {
+      return undefined;
+    }
+
+    return (
+      entryPoints.find((entryPoint) => entryPoint.entryPointType === "video" && !!entryPoint.uri)?.uri ??
+      undefined
+    );
+  }
+
+  private async waitForGoogleMeetUrl({
+    calendar,
+    calendarId,
+    eventId,
+  }: {
+    calendar: calendar_v3.Calendar;
+    calendarId: string;
+    eventId: string;
+  }): Promise<calendar_v3.Schema$Event | null> {
+    let lastKnownEvent: calendar_v3.Schema$Event | null = null;
+
+    for (let index = 0; index <= GOOGLE_MEET_URL_RETRY_DELAYS_MS.length; index++) {
+      const eventResponse = await calendar.events.get({
+        calendarId,
+        eventId,
+      });
+      lastKnownEvent = eventResponse.data;
+
+      const meetingUrl = this.extractMeetingUrl(lastKnownEvent);
+      if (meetingUrl) {
+        return lastKnownEvent;
+      }
+
+      if (index < GOOGLE_MEET_URL_RETRY_DELAYS_MS.length) {
+        await this.delay(GOOGLE_MEET_URL_RETRY_DELAYS_MS[index]);
+      }
+    }
+
+    return lastKnownEvent;
   }
 
   private getAttendees = ({
@@ -295,7 +351,17 @@ export default class GoogleCalendarService implements Calendar {
         }
       }
 
-      if (event && event.id && event.hangoutLink) {
+      if (event?.id && calEvent.location === MeetLocationType) {
+        const eventWithConference = await this.waitForGoogleMeetUrl({
+          calendar,
+          calendarId: selectedCalendar,
+          eventId: event.id,
+        });
+        event = eventWithConference || event;
+      }
+
+      const meetingUrl = this.extractMeetingUrl(event);
+      if (event && event.id && meetingUrl) {
         await calendar.events.patch({
           // Update the same event but this time we know the hangout link
           calendarId: selectedCalendar,
@@ -303,10 +369,15 @@ export default class GoogleCalendarService implements Calendar {
           requestBody: {
             description: getRichDescription({
               ...calEvent,
-              additionalInformation: { hangoutLink: event.hangoutLink },
+              additionalInformation: { hangoutLink: meetingUrl },
             }),
           },
           sendUpdates: "none",
+        });
+      } else if (calEvent.location === MeetLocationType) {
+        this.log.warn("Google Meet URL missing after creating event", {
+          eventId: event?.id,
+          selectedCalendar,
         });
       }
 
@@ -316,7 +387,7 @@ export default class GoogleCalendarService implements Calendar {
         id: event?.id || "",
         thirdPartyRecurringEventId: recurringEventId,
         additionalInfo: {
-          hangoutLink: event?.hangoutLink || "",
+          hangoutLink: meetingUrl || "",
         },
         type: "google_calendar",
         password: "",
@@ -421,7 +492,19 @@ export default class GoogleCalendarService implements Calendar {
         endTime: evt?.data.end,
       });
 
-      if (evt && evt.data.id && evt.data.hangoutLink && event.location === MeetLocationType) {
+      if (evt?.data?.id && event.location === MeetLocationType) {
+        const eventWithConference = await this.waitForGoogleMeetUrl({
+          calendar,
+          calendarId: selectedCalendar,
+          eventId: evt.data.id,
+        });
+        if (eventWithConference) {
+          evt.data = eventWithConference;
+        }
+      }
+
+      const meetingUrl = this.extractMeetingUrl(evt?.data);
+      if (evt?.data?.id && meetingUrl && event.location === MeetLocationType) {
         calendar.events.patch({
           // Update the same event but this time we know the hangout link
           calendarId: selectedCalendar,
@@ -429,7 +512,7 @@ export default class GoogleCalendarService implements Calendar {
           requestBody: {
             description: getRichDescription({
               ...event,
-              additionalInformation: { hangoutLink: evt.data.hangoutLink },
+              additionalInformation: { hangoutLink: meetingUrl },
             }),
           },
           sendUpdates: "none",
@@ -439,13 +522,18 @@ export default class GoogleCalendarService implements Calendar {
           ...evt.data,
           id: evt.data.id || "",
           additionalInfo: {
-            hangoutLink: evt.data.hangoutLink || "",
+            hangoutLink: meetingUrl || "",
           },
           type: "google_calendar",
           password: "",
           url: "",
           iCalUID: evt.data.iCalUID,
         };
+      } else if (event.location === MeetLocationType) {
+        this.log.warn("Google Meet URL missing after updating event", {
+          uid,
+          selectedCalendar,
+        });
       }
       return evt?.data;
     } catch (error) {
@@ -1423,7 +1511,19 @@ export default class GoogleCalendarService implements Calendar {
       });
 
       // 6. If there's a hangout link and we need to update the description
-      if (patchResponse.data.id && patchResponse.data.hangoutLink && event.location === MeetLocationType) {
+      if (patchResponse?.data?.id && event.location === MeetLocationType) {
+        const eventWithConference = await this.waitForGoogleMeetUrl({
+          calendar,
+          calendarId: selectedCalendar,
+          eventId: patchResponse.data.id,
+        });
+        if (eventWithConference) {
+          patchResponse.data = eventWithConference;
+        }
+      }
+
+      const meetingUrl = this.extractMeetingUrl(patchResponse?.data);
+      if (patchResponse?.data?.id && meetingUrl && event.location === MeetLocationType) {
         try {
           await calendar.events.patch({
             calendarId: selectedCalendar,
@@ -1431,7 +1531,7 @@ export default class GoogleCalendarService implements Calendar {
             requestBody: {
               description: getRichDescription({
                 ...event,
-                additionalInformation: { hangoutLink: patchResponse.data.hangoutLink },
+                additionalInformation: { hangoutLink: meetingUrl },
               }),
             },
             sendUpdates: "none",
@@ -1453,7 +1553,7 @@ export default class GoogleCalendarService implements Calendar {
         url: "",
         iCalUID: patchResponse.data.iCalUID,
         additionalInfo: {
-          hangoutLink: patchResponse.data.hangoutLink || "",
+          hangoutLink: meetingUrl || "",
         },
       };
     } catch (error) {

--- a/packages/emails/src/components/LocationInfo.tsx
+++ b/packages/emails/src/components/LocationInfo.tsx
@@ -7,6 +7,21 @@ import type { CalendarEvent } from "@calcom/types/Calendar";
 
 import { Info } from "./Info";
 
+const inferProviderNameFromMeetingUrl = (meetingUrl?: string) => {
+  if (!meetingUrl) {
+    return undefined;
+  }
+  const normalizedUrl = meetingUrl.toLowerCase();
+  if (
+    normalizedUrl.includes("meet.google.com") ||
+    normalizedUrl.includes("g.co/meet") ||
+    normalizedUrl.includes("google.com/meet")
+  ) {
+    return getEventLocationTypeFromVideoProvider("google_meet_video")?.label || "Google Meet";
+  }
+  return undefined;
+};
+
 export function LocationInfo(props: { calEvent: CalendarEvent; t: TFunction }) {
   const { t } = props;
   const bookingMetadata = (props.calEvent as CalendarEvent & { metadata?: { videoProvider?: string } | null })
@@ -15,7 +30,7 @@ export function LocationInfo(props: { calEvent: CalendarEvent; t: TFunction }) {
     typeof bookingMetadata?.videoProvider === "string" ? bookingMetadata.videoProvider : undefined;
 
   // We would not be able to determine provider name for DefaultEventLocationTypes
-  const providerName =
+  let providerName =
     getEventLocationTypeFromVideoProvider(resolvedVideoProvider)?.label ||
     guessEventLocationType(props.calEvent.location)?.label;
 
@@ -25,6 +40,11 @@ export function LocationInfo(props: { calEvent: CalendarEvent; t: TFunction }) {
   if (props.calEvent) {
     meetingUrl = getVideoCallUrlFromCalEvent(props.calEvent) || meetingUrl;
   }
+
+  if (!providerName) {
+    providerName = inferProviderNameFromMeetingUrl(meetingUrl) || inferProviderNameFromMeetingUrl(location);
+  }
+  const shouldShowRawMeetingUrl = !providerName || providerName === "Link";
 
   const isPhone = location?.startsWith("+");
 
@@ -48,6 +68,7 @@ export function LocationInfo(props: { calEvent: CalendarEvent; t: TFunction }) {
           </a>
         }
         extraInfo={
+          shouldShowRawMeetingUrl &&
           meetingUrl && (
             <div style={{ color: "#494949", fontWeight: 400, lineHeight: "24px" }}>
               <>

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -226,6 +226,49 @@ function isSameUTC(a: Date, b: Date): boolean {
   return dayjs(a).utc().isSame(dayjs(b).utc(), "second");
 }
 
+function propagateGoogleMeetUrl({
+  bookingLocation,
+  meetingUrl,
+  evt,
+  referencesToCreate,
+  loggerWithEventDetails,
+  phase,
+}: {
+  bookingLocation: string;
+  meetingUrl?: string;
+  evt: CalendarEvent;
+  referencesToCreate: PartialReference[];
+  loggerWithEventDetails: ReturnType<typeof createLoggerWithEventDetails>;
+  phase: "create" | "reschedule";
+}) {
+  if (bookingLocation !== MeetLocationType) {
+    return;
+  }
+
+  if (!meetingUrl || !meetingUrl.startsWith("http")) {
+    loggerWithEventDetails.warn(
+      "Google Meet URL missing after calendar operation",
+      safeStringify({
+        phase,
+        bookingUid: evt.uid,
+        locationType: bookingLocation,
+        referenceTypes: referencesToCreate.map((ref) => ref.type),
+      })
+    );
+    return;
+  }
+
+  evt.location = meetingUrl;
+  referencesToCreate.forEach((reference) => {
+    if (
+      (reference.type === "google_calendar" || reference.type === "google_meet_video") &&
+      !reference.meetingUrl
+    ) {
+      reference.meetingUrl = meetingUrl;
+    }
+  });
+}
+
 type BookingDataSchemaGetter =
   | typeof getBookingDataSchema
   | typeof import("@calcom/features/bookings/lib/getBookingDataSchemaForApi").default;
@@ -2043,6 +2086,14 @@ async function handler(
           organizerOrFirstDynamicGroupMemberDefaultLocationUrl ||
           getVideoCallUrlFromCalEvent(evt) ||
           videoCallUrl;
+        propagateGoogleMeetUrl({
+          bookingLocation,
+          meetingUrl: conferenceDetails.meetingUrl,
+          evt,
+          referencesToCreate,
+          loggerWithEventDetails,
+          phase: "reschedule",
+        });
       }
 
       const calendarResult = results.find((result) => result.type.includes("_calendar"));
@@ -2278,6 +2329,14 @@ async function handler(
           conferenceDetails.meetingUrl ||
           organizerOrFirstDynamicGroupMemberDefaultLocationUrl ||
           videoCallUrl;
+        propagateGoogleMeetUrl({
+          bookingLocation,
+          meetingUrl: conferenceDetails.meetingUrl,
+          evt,
+          referencesToCreate,
+          loggerWithEventDetails,
+          phase: "create",
+        });
 
         if (!isDryRun && evt.iCalUID !== booking.iCalUID) {
           // The eventManager could change the iCalUID. At this point we can update the DB record
@@ -2568,6 +2627,17 @@ async function handler(
 
   try {
     if (!isDryRun) {
+      if (bookingLocation === MeetLocationType && (!evt.location || !evt.location.startsWith("http"))) {
+        loggerWithEventDetails.warn(
+          "Persisting booking without canonical Google Meet URL",
+          safeStringify({
+            bookingUid: booking.uid,
+            locationType: bookingLocation,
+            persistedLocation: evt.location,
+          })
+        );
+      }
+
       await prisma.booking.update({
         where: {
           uid: booking.uid,


### PR DESCRIPTION
## Summary
This PR fixes inconsistent Google Meet handling in the booking confirmation flow by making meeting-link capture deterministic and using one canonical URL across downstream surfaces.

## Problem
For some bookings with location set to Google Meet:
- Google Calendar event had the Meet URL
- But our system sometimes missed it in:
  - `Booking.location` / references
  - confirmation emails
  - booking confirmation page (`Where` section)

Also, UI/email provider labeling could fall back to `Link` instead of `Google Meet` once location became a raw URL.

## Root Cause
- Google Meet link availability can be eventually consistent after Calendar create/update calls.
- Booking flow could proceed before `hangoutLink`/video entry points were consistently available.
- Provider label inference relied on type metadata that may be absent when location is stored as a plain URL.

