### PR TITLE
enh(webhook):added cancellation and reschedule urls to booking event …

### DIFF
--- a/apps/web/test/utils/bookingScenario/expects.ts
+++ b/apps/web/test/utils/bookingScenario/expects.ts
@@ -275,27 +275,7 @@ export function expectWebhookToHaveBeenCalledWith(
     payload: Record<string, unknown> | null;
   }
 ) {
-  const fetchCalls = fetchMock.mock.calls;
-  const webhooksToSubscriberUrl = fetchCalls.filter((call) => {
-    return call[0] === subscriberUrl;
-  });
-  logger.silly("Scanning fetchCalls for webhook", safeStringify(fetchCalls));
-  const webhookFetchCall = webhooksToSubscriberUrl.find((call) => {
-    const body = call[1]?.body;
-    const parsedBody = JSON.parse((body as string) || "{}");
-    return parsedBody.triggerEvent === data.triggerEvent;
-  });
-
-  if (!webhookFetchCall) {
-    throw new Error(
-      `Webhook not sent to ${subscriberUrl} for ${data.triggerEvent}. All webhooks: ${JSON.stringify(
-        webhooksToSubscriberUrl
-      )}`
-    );
-  }
-  expect(webhookFetchCall[0]).toBe(subscriberUrl);
-  const body = webhookFetchCall[1]?.body;
-  const parsedBody = JSON.parse((body as string) || "{}");
+  const parsedBody = getWebhookBodyForTrigger({ subscriberUrl, triggerEvent: data.triggerEvent });
 
   expect(parsedBody.triggerEvent).toBe(data.triggerEvent);
 
@@ -314,6 +294,36 @@ export function expectWebhookToHaveBeenCalledWith(
       expect(parsedBody.payload).toEqual(expect.objectContaining(remainingPayload));
     }
   }
+}
+
+function getWebhookBodyForTrigger({
+  subscriberUrl,
+  triggerEvent,
+}: {
+  subscriberUrl: string;
+  triggerEvent: WebhookTriggerEvents;
+}) {
+  const fetchCalls = fetchMock.mock.calls;
+  const webhooksToSubscriberUrl = fetchCalls.filter((call) => call[0] === subscriberUrl);
+
+  logger.silly("Scanning fetchCalls for webhook", safeStringify(fetchCalls));
+
+  const webhookFetchCall = webhooksToSubscriberUrl.find((call) => {
+    const body = call[1]?.body;
+    const parsedBody = JSON.parse((body as string) || "{}");
+    return parsedBody.triggerEvent === triggerEvent;
+  });
+
+  if (!webhookFetchCall) {
+    throw new Error(
+      `Webhook not sent to ${subscriberUrl} for ${triggerEvent}. All webhooks: ${JSON.stringify(
+        webhooksToSubscriberUrl
+      )}`
+    );
+  }
+
+  expect(webhookFetchCall[0]).toBe(subscriberUrl);
+  return JSON.parse((webhookFetchCall[1]?.body as string) || "{}");
 }
 
 export function expectWorkflowToBeTriggered({
@@ -1008,6 +1018,14 @@ export function expectBookingRequestedWebhookToHaveBeenFired({
       },
     });
   }
+
+  const parsedBody = getWebhookBodyForTrigger({
+    subscriberUrl,
+    triggerEvent: "BOOKING_REQUESTED",
+  });
+
+  expect(parsedBody.payload?.cancellationUrl).toBeUndefined();
+  expect(parsedBody.payload?.rescheduleUrl).toBeUndefined();
 }
 
 export function expectBookingCreatedWebhookToHaveBeenFired({
@@ -1016,6 +1034,8 @@ export function expectBookingCreatedWebhookToHaveBeenFired({
   subscriberUrl,
   paidEvent,
   videoCallUrl,
+  cancellationUrl,
+  rescheduleUrl,
   isEmailHidden = false,
   isAttendeePhoneNumberHidden = false,
 }: {
@@ -1025,6 +1045,8 @@ export function expectBookingCreatedWebhookToHaveBeenFired({
   location: string;
   paidEvent?: boolean;
   videoCallUrl?: string | null;
+  cancellationUrl?: string;
+  rescheduleUrl?: string;
   isEmailHidden?: boolean;
   isAttendeePhoneNumberHidden?: boolean;
 }) {
@@ -1035,6 +1057,8 @@ export function expectBookingCreatedWebhookToHaveBeenFired({
         metadata: {
           ...(videoCallUrl ? { videoCallUrl } : null),
         },
+        ...(cancellationUrl ? { cancellationUrl } : null),
+        ...(rescheduleUrl ? { rescheduleUrl } : null),
         responses: {
           name: { label: "your_name", value: booker.name, isHidden: false },
           email: { label: "email_address", value: booker.email, isHidden: isEmailHidden },
@@ -1093,6 +1117,8 @@ export function expectBookingRescheduledWebhookToHaveBeenFired({
   location,
   subscriberUrl,
   videoCallUrl,
+  cancellationUrl,
+  rescheduleUrl,
   payload,
 }: {
   organizer: { email: string; name: string };
@@ -1101,12 +1127,16 @@ export function expectBookingRescheduledWebhookToHaveBeenFired({
   location: string;
   paidEvent?: boolean;
   videoCallUrl?: string;
+  cancellationUrl?: string;
+  rescheduleUrl?: string;
   payload?: Record<string, unknown>;
 }) {
   expectWebhookToHaveBeenCalledWith(subscriberUrl, {
     triggerEvent: "BOOKING_RESCHEDULED",
     payload: {
       ...payload,
+      ...(cancellationUrl ? { cancellationUrl } : null),
+      ...(rescheduleUrl ? { rescheduleUrl } : null),
       metadata: {
         ...(videoCallUrl ? { videoCallUrl } : null),
       },

--- a/docs/developing/guides/automation/webhooks.mdx
+++ b/docs/developing/guides/automation/webhooks.mdx
@@ -6,7 +6,7 @@ title: "Webhooks"
 Webhooks offer a great way to automate the flow with other apps when invitees schedule, cancel or reschedule events, or when the meeting ends. 
 <iframe style={{ width: "100%", maxWidth: "560px" }} height="315" src="https://www.youtube.com/embed/Yy9me5E09LA?si=_2Mz-CKL2ajsFivd" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
-The webhook subscription allows you to listen to specific trigger events, such as when a booking has been scheduled, for example. You can always listen to the webhook by providing a custom subscriber URL with your own development work. However, if you wish to trigger automations without any development work, you can use the integration with Zapier which connects Cal.com to your apps.
+The webhook subscription allows you to listen to specific trigger events, such as when a booking has been scheduled, for example. You can always listen to the webhook by providing a custom subscriber URL with your own development work. However, if you wish to trigger automations without any development work, you can use the integration with Zapier which connects Cal ID to your apps.
 
 <Note>
 Please note that the webhooks can be associated with user as well as individual event types, including team event types.
@@ -138,6 +138,8 @@ To create a new webhook subscription, visit `/settings/developer/webhooks` and p
         "length": 60,
         "bookingId": 91,
         "metadata": {},
+        "cancellationUrl": "https://cal.id/booking/bFJeNb2uX8ANpT3JL5EfXw?cancel=true&allRemainingBookings=false",
+        "rescheduleUrl": "https://cal.id/reschedule/bFJeNb2uX8ANpT3JL5EfXw",
         "status": "ACCEPTED"
     }
 }
@@ -194,6 +196,8 @@ where `{{type}}` represents the event type slug and `{{title}}` represents the t
 | attendees          | Person[]     | The event booker & any guests                                                                                                                                 |
 | uid                | String       | The UID of the booking                                                                                                                                        |
 | rescheduleUid      | String       | The UID for rescheduling                                                                                                                                      |
+| cancellationUrl    | String       | Public booking cancellation link. Sent when available for accepted bookings (e.g. BOOKING_CREATED and BOOKING_RESCHEDULED).                                 |
+| rescheduleUrl      | String       | Public booking reschedule link. Sent when available for accepted bookings (e.g. BOOKING_CREATED and BOOKING_RESCHEDULED).                                   |
 | cancellationReason | String       | Reason for cancellation                                                                                                                                       |
 | rejectionReason    | String       | Reason for rejection                                                                                                                                          |
 | team.name          | String       | Name of the team booked                                                                                                                                       |

--- a/packages/features/bookings/lib/addBookingManagementUrlsToWebhookPayload.test.ts
+++ b/packages/features/bookings/lib/addBookingManagementUrlsToWebhookPayload.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type { EventPayloadType } from "@calcom/features/webhooks/lib/sendPayload";
+import { WEBAPP_URL } from "@calcom/lib/constants";
+
+import { addBookingManagementUrlsToWebhookPayload } from "./addBookingManagementUrlsToWebhookPayload";
+
+const t = vi.fn();
+
+const buildPayload = (overrides: Partial<EventPayloadType> = {}): EventPayloadType => ({
+  type: "30min",
+  title: "Intro call",
+  startTime: "2026-04-01T10:00:00.000Z",
+  endTime: "2026-04-01T10:30:00.000Z",
+  organizer: {
+    name: "Organizer",
+    email: "organizer@example.com",
+    timeZone: "UTC",
+    language: { translate: t as any, locale: "en" },
+    username: "organizer",
+  },
+  attendees: [
+    {
+      name: "Booker",
+      email: "booker@example.com",
+      timeZone: "UTC",
+      language: { translate: t as any, locale: "en" },
+    },
+  ],
+  uid: "booking_uid",
+  status: "ACCEPTED",
+  ...overrides,
+});
+
+describe("addBookingManagementUrlsToWebhookPayload", () => {
+  test("includes cancellation + reschedule URLs for accepted bookings", () => {
+    const payload = buildPayload();
+
+    const enriched = addBookingManagementUrlsToWebhookPayload(payload);
+
+    expect(enriched.cancellationUrl).toBe(
+      `${WEBAPP_URL}/booking/${payload.uid}?cancel=true&allRemainingBookings=false`
+    );
+    expect(enriched.rescheduleUrl).toBe(`${WEBAPP_URL}/reschedule/${payload.uid}`);
+  });
+
+  test("does not include management URLs for pending bookings", () => {
+    const payload = buildPayload({ status: "PENDING" });
+
+    const enriched = addBookingManagementUrlsToWebhookPayload(payload);
+
+    expect(enriched.cancellationUrl).toBeUndefined();
+    expect(enriched.rescheduleUrl).toBeUndefined();
+  });
+
+  test("does not include URL when cancelling/rescheduling is disabled", () => {
+    const payload = buildPayload({ disableCancelling: true, disableRescheduling: true });
+
+    const enriched = addBookingManagementUrlsToWebhookPayload(payload);
+
+    expect(enriched.cancellationUrl).toBeUndefined();
+    expect(enriched.rescheduleUrl).toBeUndefined();
+  });
+});

--- a/packages/features/bookings/lib/addBookingManagementUrlsToWebhookPayload.ts
+++ b/packages/features/bookings/lib/addBookingManagementUrlsToWebhookPayload.ts
@@ -1,0 +1,45 @@
+import type { EventPayloadType } from "@calcom/features/webhooks/lib/sendPayload";
+import { getCancelLink, getRescheduleLink } from "@calcom/lib/CalEventParser";
+import { BookingStatus } from "@calcom/prisma/enums";
+
+const BOOKING_WEBHOOK_STATUS_ACCEPTED = BookingStatus.ACCEPTED;
+
+/**
+ * Adds public booking management URLs to webhook payloads when the booking is in an accepted state.
+ */
+export const addBookingManagementUrlsToWebhookPayload = (
+  payload: EventPayloadType
+): EventPayloadType & { cancellationUrl?: string; rescheduleUrl?: string } => {
+  if (payload.status !== BOOKING_WEBHOOK_STATUS_ACCEPTED || !payload.uid) {
+    return payload;
+  }
+
+  const urls: { cancellationUrl?: string; rescheduleUrl?: string } = {};
+
+  if (!payload.disableCancelling) {
+    try {
+      const cancellationUrl = getCancelLink(payload);
+      if (cancellationUrl) {
+        urls.cancellationUrl = cancellationUrl;
+      }
+    } catch {
+      // Keep webhook payload resilient if URL building fails for malformed event data.
+    }
+  }
+
+  if (!payload.disableRescheduling) {
+    try {
+      const rescheduleUrl = getRescheduleLink({ calEvent: payload });
+      if (rescheduleUrl) {
+        urls.rescheduleUrl = rescheduleUrl;
+      }
+    } catch {
+      // Keep webhook payload resilient if URL building fails for malformed event data.
+    }
+  }
+
+  return {
+    ...payload,
+    ...urls,
+  };
+};

--- a/packages/features/bookings/lib/handleConfirmation.ts
+++ b/packages/features/bookings/lib/handleConfirmation.ts
@@ -31,6 +31,7 @@ import { EventTypeMetaDataSchema, eventTypeAppMetadataOptionalSchema } from "@ca
 import { getAllCalIdWorkflowsFromEventType } from "@calcom/trpc/server/routers/viewer/workflows/util.calid";
 import type { AdditionalInformation, CalendarEvent, RecurringEvent, Person } from "@calcom/types/Calendar";
 
+import { addBookingManagementUrlsToWebhookPayload } from "./addBookingManagementUrlsToWebhookPayload";
 import { getCalEventResponses } from "./getCalEventResponses";
 import {
   getConferenceDetailsFromResult,
@@ -526,7 +527,7 @@ export async function handleConfirmation(args: {
       length: eventType?.length,
     };
 
-    const payload: EventPayloadType = {
+    const payload: EventPayloadType = addBookingManagementUrlsToWebhookPayload({
       ...evt,
       ...eventTypeInfo,
       bookingId,
@@ -541,7 +542,7 @@ export async function handleConfirmation(args: {
             }
           : undefined,
       ...(platformClientParams ? platformClientParams : {}),
-    };
+    });
 
     const promises = subscribersBookingCreated.map((sub) =>
       sendPayload(

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -30,6 +30,7 @@ import {
 } from "@calcom/emails";
 import getICalUID from "@calcom/emails/lib/getICalUID";
 import { CalendarEventBuilder } from "@calcom/features/CalendarEventBuilder";
+import { addBookingManagementUrlsToWebhookPayload } from "@calcom/features/bookings/lib/addBookingManagementUrlsToWebhookPayload";
 import { handleWebhookTrigger } from "@calcom/features/bookings/lib/handleWebhookTrigger";
 import { isEventTypeLoggingEnabled } from "@calcom/features/bookings/lib/isEventTypeLoggingEnabled";
 import { getShouldServeCache } from "@calcom/features/calendar-cache/lib/getShouldServeCache";
@@ -2609,7 +2610,7 @@ async function handler(
     await handleWebhookTrigger({
       subscriberOptions,
       eventTrigger,
-      webhookData,
+      webhookData: addBookingManagementUrlsToWebhookPayload(webhookData),
       isDryRun,
     });
   } else {

--- a/packages/features/bookings/lib/handleNewBooking/test/fresh-booking.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/fresh-booking.test.ts
@@ -409,6 +409,8 @@ describe("handleNewBooking", () => {
             location: BookingLocations.CalVideo,
             subscriberUrl: "http://my-webhook.example.com",
             videoCallUrl: `${WEBAPP_URL}/video/${createdBooking.uid}`,
+            cancellationUrl: `${WEBAPP_URL}/booking/${createdBooking.uid}?cancel=true&allRemainingBookings=false`,
+            rescheduleUrl: `${WEBAPP_URL}/reschedule/${createdBooking.uid}`,
           });
         },
         timeout

--- a/packages/features/bookings/lib/handleNewBooking/test/reschedule.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/reschedule.test.ts
@@ -288,6 +288,8 @@ describe("handleNewBooking", () => {
             location: BookingLocations.CalVideo,
             subscriberUrl: "http://my-webhook.example.com",
             videoCallUrl: `${WEBAPP_URL}/video/${createdBooking.uid}`,
+            cancellationUrl: `${WEBAPP_URL}/booking/${createdBooking.uid}?cancel=true&allRemainingBookings=false`,
+            rescheduleUrl: `${WEBAPP_URL}/reschedule/${createdBooking.uid}`,
             payload: {
               rescheduledBy: organizer.email,
             },

--- a/packages/features/bookings/lib/handleSeats/handleSeats.ts
+++ b/packages/features/bookings/lib/handleSeats/handleSeats.ts
@@ -3,6 +3,7 @@ import { scheduleWorkflowReminders } from "@calid/features/modules/workflows/uti
 import { uuid } from "short-uuid";
 
 import dayjs from "@calcom/dayjs";
+import { addBookingManagementUrlsToWebhookPayload } from "@calcom/features/bookings/lib/addBookingManagementUrlsToWebhookPayload";
 import { handleWebhookTrigger } from "@calcom/features/bookings/lib/handleWebhookTrigger";
 import type { EventPayloadType } from "@calcom/features/webhooks/lib/sendPayload";
 import { ErrorCode } from "@calcom/lib/errorCodes";
@@ -207,7 +208,12 @@ const handleSeats = async (newSeatedBookingObject: NewSeatedBookingObject) => {
       rescheduledBy,
     };
 
-    await handleWebhookTrigger({ subscriberOptions, eventTrigger, webhookData, isDryRun });
+    await handleWebhookTrigger({
+      subscriberOptions,
+      eventTrigger,
+      webhookData: addBookingManagementUrlsToWebhookPayload(webhookData),
+      isDryRun,
+    });
   }
 
   return resultBooking;

--- a/packages/features/webhooks/lib/sendPayload.ts
+++ b/packages/features/webhooks/lib/sendPayload.ts
@@ -79,6 +79,8 @@ export type EventPayloadType = CalendarEvent &
   TranscriptionGeneratedPayload &
   EventTypeInfo & {
     metadata?: { [key: string]: string | number | boolean | null };
+    cancellationUrl?: string;
+    rescheduleUrl?: string;
     bookingId?: number;
     status?: string;
     smsReminderNumber?: string;


### PR DESCRIPTION

## Summary
This PR updates booking webhook payloads to include booking management URLs when they are valid and expected:

- `cancellationUrl`
- `rescheduleUrl`

These fields are now added for:
1. newly created bookings that are confirmed (`ACCEPTED`)  
2. rescheduled bookings (`BOOKING_RESCHEDULED` path)

Pending/requested bookings are unchanged and do **not** expose these URLs before confirmation.

## Root Cause
Webhook payloads in booking flows were built from `evt` + event metadata but never enriched with booking management links, even though canonical link generation already exists in `CalEventParser`.

## What changed
### 1) Added shared payload enricher
- `packages/features/bookings/lib/addBookingManagementUrlsToWebhookPayload.ts`

Uses canonical helpers:
- `getCancelLink`
- `getRescheduleLink`

Guardrails:
- only when `status === ACCEPTED`
- only when `uid` exists
- respects `disableCancelling` / `disableRescheduling`
- omits fields if URL cannot be built (no broken `null/undefined` payload values)

### 2) Applied to all relevant booking webhook emitters
- `packages/features/bookings/lib/handleNewBooking.ts`
- `packages/features/bookings/lib/handleSeats/handleSeats.ts`
- `packages/features/bookings/lib/handleConfirmation.ts`

### 3) Updated webhook payload typing
- `packages/features/webhooks/lib/sendPayload.ts`
  - added optional:
    - `cancellationUrl?: string`
    - `rescheduleUrl?: string`

### 4) Test updates
- Added new unit tests:
  - `packages/features/bookings/lib/addBookingManagementUrlsToWebhookPayload.test.ts`
  - covers:
    - accepted booking includes both URLs
    - pending booking includes neither
    - disable flags suppress URLs
- Updated booking webhook expectation helpers:
  - `apps/web/test/utils/bookingScenario/expects.ts`
  - `BOOKING_REQUESTED` now explicitly asserts URLs are absent
- Updated scenario assertions for created/rescheduled payloads:
  - `packages/features/bookings/lib/handleNewBooking/test/fresh-booking.test.ts`
  - `packages/features/bookings/lib/handleNewBooking/test/reschedule.test.ts`

### 5) Documentation
- `docs/developing/guides/automation/webhooks.mdx`
  - payload example updated with new fields
  - webhook variable list updated

## Backward compatibility
- Existing payload shape remains unchanged except for two new optional fields.
- Signing/serialization behavior unchanged.
- `BOOKING_REQUESTED` remains unchanged (no management URLs before confirmation).