### PR TITLE
enh(teams):Fix team impersonation stop flow to restore original session instead of logout

### DIFF
--- a/packages/calid/modules/impersonation/ImpersonationProvider.tsx
+++ b/packages/calid/modules/impersonation/ImpersonationProvider.tsx
@@ -254,12 +254,6 @@ class ImpersonationHandlers {
     const originalUser = await ImpersonationQueries.fetchReturningUser(parsedReturnId);
     if (!originalUser) return undefined;
 
-    const hasOrgContext =
-      originalUser.organizationId || originalUser.profiles.some((p) => p.organizationId !== undefined);
-
-    const canReturn = originalUser.role === "ADMIN" || hasOrgContext;
-    if (!canReturn) return undefined;
-
     const userProfile = await ProfileManager.resolveUserProfile(originalUser);
 
     return {

--- a/packages/calid/modules/impersonation/components/ImpersonationBanner.tsx
+++ b/packages/calid/modules/impersonation/components/ImpersonationBanner.tsx
@@ -1,6 +1,5 @@
-import { resetCrispSession } from "@calid/features/modules/support/hooks/crispLogout";
 import type { SessionContextValue } from "next-auth/react";
-import { signIn, signOut } from "next-auth/react";
+import { signIn } from "next-auth/react";
 
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { TopBanner } from "@calcom/ui/components/top-banner";
@@ -15,38 +14,27 @@ function ImpersonationBanner({ data }: ImpersonationBannerProps) {
   const impersonator = data?.user.impersonatedBy;
   if (!impersonator) return null;
 
-  const isAdminOrOrgUser = impersonator.role === "ADMIN" || !!data.user?.org?.id;
-
   const handleStopImpersonation = (e: React.FormEvent) => {
     e.preventDefault();
-    signIn("impersonation-auth", { returnToId: impersonator.id });
+    signIn("impersonation-auth", {
+      returnToId: impersonator.id.toString(),
+    });
   };
-
-  const handleStopImpersonationForNormalUser = async (e: React.FormEvent) => {
-    e.preventDefault();
-    await resetCrispSession();
-    signOut({ callbackUrl: "/auth/logout" });
-  };
-
-  const actionButton = isAdminOrOrgUser ? (
-    <form onSubmit={handleStopImpersonation}>
-      <button type="submit" className="text-emphasis hover:underline" data-testid="stop-impersonating-button">
-        {t("impersonating_stop_instructions")}
-      </button>
-    </form>
-  ) : (
-    <form onSubmit={handleStopImpersonationForNormalUser}>
-      <button type="submit" className="text-emphasis hover:underline" data-testid="stop-impersonating-button">
-        {t("impersonating_stop_instructions")}
-      </button>
-    </form>
-  );
 
   return (
     <TopBanner
       text={t("impersonating_user_warning", { user: data.user.username })}
       variant="warning"
-      actions={actionButton}
+      actions={
+        <form onSubmit={handleStopImpersonation}>
+          <button
+            type="submit"
+            className="text-emphasis hover:underline"
+            data-testid="stop-impersonating-button">
+            {t("impersonating_stop_instructions")}
+          </button>
+        </form>
+      }
     />
   );
 }


### PR DESCRIPTION

## Summary
This PR fixes a regression in team-member impersonation where clicking **Stop Impersonation** ended both sessions and redirected users to login.

## Root cause
- Team impersonation stop action could take a `signOut` path, which cleared the full auth session.
- Return-to-original logic had an extra eligibility check that could block valid restoration even when `returnToId` matched the impersonator.

## Expected behavior after fix
- Stop only the impersonated session
- Restore original admin/owner session automatically
- No forced re-authentication

## Scope
Minimal, localized fix:
- `packages/calid/modules/impersonation/components/ImpersonationBanner.tsx`
- `packages/calid/modules/impersonation/ImpersonationProvider.tsx`

closes #1130 